### PR TITLE
Hide proposals from normal users

### DIFF
--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -181,6 +181,11 @@ def workshop_view(request, name=None):
         else:
             has_perm_to_edit = False
 
+    # Workshop proposals are only visible to admins
+    has_perm_to_see_all = request.user.has_perm('wwwapp.see_all_workshops')
+    if not has_perm_to_edit and not has_perm_to_see_all:
+        return redirect('login')
+
     if has_perm_to_edit:
         if request.method == 'POST':
             form = WorkshopForm(request.POST, instance=workshop)


### PR DESCRIPTION
Any logged in user was able to view workshop proposals if they entered the URL maually

SECURITY FAIL!