### PR TITLE
Remove old data from start/end_data in migration 0054

### DIFF
--- a/wwwapp/migrations/0054_auto_20190713_0313.py
+++ b/wwwapp/migrations/0054_auto_20190713_0313.py
@@ -14,14 +14,22 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RemoveField(
             model_name='userinfo',
+            name='end_date',
+        ),
+        migrations.RemoveField(
+            model_name='userinfo',
+            name='start_date',
+        ),
+        migrations.RemoveField(
+            model_name='userinfo',
             name='meeting_point',
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='userinfo',
             name='end_date',
             field=models.DateField(blank=True, null=True),
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='userinfo',
             name='start_date',
             field=models.DateField(blank=True, null=True),


### PR DESCRIPTION
Remove old data from `UserInfo.start/end_date` in migration 0054

This fixes migration errors as field type can't be simply altered from
CharField to DateField

This fixes #77