### PR TITLE
Fix datatable bugs

### DIFF
--- a/static/js/datatables.intl.js
+++ b/static/js/datatables.intl.js
@@ -1,0 +1,86 @@
+/**
+ * This sorting type will replace DataTables' default string sort with one that
+ * will use a locale aware collator. This is supported by IE11, Edge, Chrome,
+ * Firefox and Safari 10+. Any browser that does not support the Intl will
+ * simply fall back to UTF8 string sorting.
+ *
+ * This method simply needs to be called prior to the DataTables' initialisation
+ * to replace the default string sort with locale aware sorting. The method
+ * optionally takes two arguments:
+ *
+ * 1. [Optional] Locale or array of locales
+ * 2. [Optional] Collator options
+ *
+ * For the supported options please see the
+ * [MDN Intl documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator).
+ *
+ * @name intl
+ * @summary Sort string data using the Intl Javascript API
+ * @author [Allan Jardine](//datatables.net)
+ * @depends DataTables 1.10+
+ *
+ * @example
+ *    // Host's current locale
+ *    $.fn.dataTable.ext.order.intl();
+ *
+ * @example
+ *    // Explicit locale
+ *    $.fn.dataTable.ext.order.intl('de-u-co-phonebk');
+ *
+ * @example
+ *    // Locale with configuration options
+ *    $.fn.dataTable.ext.order.intl('fr', {
+ *      sensitivity: 'base'
+ *    } );
+ */
+
+
+// UMD
+(function( factory ) {
+	"use strict";
+
+	if ( typeof define === 'function' && define.amd ) {
+		// AMD
+		define( ['jquery'], function ( $ ) {
+			return factory( $, window, document );
+		} );
+	}
+	else if ( typeof exports === 'object' ) {
+		// CommonJS
+		module.exports = function (root, $) {
+			if ( ! root ) {
+				root = window;
+			}
+
+			if ( ! $ ) {
+				$ = typeof window !== 'undefined' ?
+					require('jquery') :
+					require('jquery')( root );
+			}
+
+			return factory( $, root, root.document );
+		};
+	}
+	else {
+		// Browser
+		factory( jQuery, window, document );
+	}
+}
+(function( $, window, document ) {
+
+
+$.fn.dataTable.ext.order.intl = function ( locales, options ) {
+	if ( window.Intl ) {
+		var collator = new Intl.Collator( locales, options );
+		var types = $.fn.dataTable.ext.type;
+
+		delete types.order['string-pre'];
+		types.order['string-asc'] = collator.compare;
+		types.order['string-desc'] = function ( a, b ) {
+			return collator.compare( a, b ) * -1;
+		};
+	}
+};
+
+
+}));

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html lang="en">
   {% load staticfiles %}
   {% load compress %}
+  {% load i18n %}
 
   <head>
     <meta charset="utf-8">
@@ -175,6 +176,7 @@
       <script type="text/javascript" src="{% static 'js/pdfmake.min.js' %}"></script>
       <script type="text/javascript" src="{% static 'js/vfs_fonts.js' %}"></script>
       <script type="text/javascript" src="{% static 'js/datatables.min.js' %}"></script>
+      <script type="text/javascript" src="{% static 'js/datatables.intl.js' %}"></script>
 
       <script src="{% static 'js/moment.js' %}"></script>
       <script src="{% static 'js/moment-locale-pl.js' %}"></script>
@@ -183,6 +185,8 @@
       <script src="{% static 'js/ajax.requests.js' %}"></script>
       <script src="{% static 'js/warsztatywww.js' %}"></script>
     {% endcompress %}
+    {% get_current_language as LANGUAGE_CODE %}
+    <script>$.fn.dataTable.ext.order.intl('{{ LANGUAGE_CODE }}');</script>
 
     {% block script %}{% endblock %}
     <!-- Mathjax / LaTeX support-->

--- a/templates/lecturers.html
+++ b/templates/lecturers.html
@@ -8,22 +8,22 @@
     <article class="col-sm-12 maincontent">
       <h1>Wszyscy prowadzący</h1>
       <div class="table-responsive">
-        <table id="participants-table" class="table" style="width:100%!important;">
+        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 6, "desc" ], [ 1, "desc" ]]'>
           <thead>
             <tr>
-              <th></th>
-              <th>Imię i nazwisko</th>
-              <th>Data Urodzenia</th>
-              <th>Pełnoletni</th>
-              <th>Email</th>
-              <th>Warsztaty</th>
-              <th>Komentarz</th>
-              <th>Pesel</th>
-              <th>Adres</th>
-              <th>Numer telefonu</th>
-              <th>Rozmiar Koszulki</th>
-              <th>Data Przyjazdu</th>
-              <th>Data Wyjazdu</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="false"></th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="true">Imię i nazwisko</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Urodzenia</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Pełnoletni</th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="true">Email</th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="false">Warsztaty</th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="false">Komentarz</th>
+              <th data-visible="false" data-searchable="false" data-orderable="false">Pesel</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="false">Adres</th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="false">Numer telefonu</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Rozmiar Koszulki</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Przyjazdu</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Wyjazdu</th>
             </tr>
           </thead>
           <tbody>
@@ -120,29 +120,6 @@
                 }
            },
         ],
-        "columnDefs": [
-          {
-            "orderable": false,
-            targets: [0, 5]
-          },
-          {
-            visible: true,
-            targets: [0, 1, 4, 5, 6, 9]
-          },
-          {
-            visible: false,
-            targets: "_all"
-          },
-          {
-            "searchable": true,
-            // Name, Email, Workshops, Comment, Address, Phone number
-            targets: [1, 4, 5, 6, 8, 9]
-          },
-          {
-            "searchable": false,
-            targets: "_all"
-          }
-          ],
         "language": {
           "url": "{% static 'datatables/Polish.json' %}",
         },
@@ -150,7 +127,6 @@
           $("td:first", nRow).html(iDisplayIndex +1);
           return nRow;
         },
-        "order": [[ 6, "desc" ], [ 1, "desc" ]],
       });
     }
     );

--- a/templates/lecturers.html
+++ b/templates/lecturers.html
@@ -31,12 +31,12 @@
               <tr>
                 <td>
                 </td>
-                <td>
+                <td data-order="{{ person.user.last_name }} {{ person.user.first_name }}">
                   <a href="{% url 'profile' person.user.id %}">
                     {{ person.user.get_full_name | question_mark_on_empty_string }}
                   </a>
                 </td>
-                <td>
+                <td data-order="{{ person.birth | date:"U" }}">
                   {{ person.birth | question_mark_on_none_value }}
                 </td>
                 <td>
@@ -68,10 +68,10 @@
                 <td>
                   {{ person.tshirt_size }}
                 </td>
-                <td>
+                <td data-order="{{ person.start_date | date:"U" }}">
                   {{ person.start_date }}
                 </td>
-                <td>
+                <td data-order="{{ person.end_date | date:"U" }}">
                   {{ person.end_date }}
                 </td>
               </tr>

--- a/templates/lecturers.html
+++ b/templates/lecturers.html
@@ -8,7 +8,7 @@
     <article class="col-sm-12 maincontent">
       <h1>Wszyscy prowadzący</h1>
       <div class="table-responsive">
-        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 6, "desc" ], [ 1, "desc" ]]'>
+        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 1, "asc" ]]'>
           <thead>
             <tr>
               <th data-visible="true"  data-searchable="false" data-orderable="false"></th>

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -8,28 +8,28 @@
     <article class="col-sm-12 maincontent">
       <h1>Wszyscy uczestnicy</h1>
       <div class="table-responsive">
-        <table id="participants-table" class="table" style="width:100%!important;">
+        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 1, "desc" ], [ 11, "desc" ]]'>
           <thead>
             <tr>
-              <th></th>
-              <th>Imię i nazwisko</th>
-              <th>Data Urodzenia</th>
-              <th>Pełnoletni</th>
-              <th>Email</th>
-              <th>Szkoła</th>
-              <th>Rok Matury</th>
-              <th>Punkty</th>
-              <th>Suma ilości warsztatów</th>
-              <th>Ilość Zakwalifikowanych Warsztatów</th>
-              <th>List motywacyjny</th>
-              <th>Status</th>
-              <th>Komentarz</th>
-              <th>Pesel</th>
-              <th>Adres</th>
-              <th>Numer telefonu</th>
-              <th>Rozmiar Koszulki</th>
-              <th>Data Przyjazdu</th>
-              <th>Data Wyjazdu</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="false"></th>
+              <th data-visible="true"  data-searchable="true"  data-orderable="true">Imię i nazwisko</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Urodzenia</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="true">Pełnoletni</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="true">Email</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="true">Szkoła</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Rok Matury</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="true">Punkty</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Suma ilości warsztatów</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Ilość Zakwalifikowanych Warsztatów</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="true">List motywacyjny</th>
+              <th data-visible="true"  data-searchable="false" data-orderable="true">Status</th>
+              <th data-visible="false" data-searchable="false" data-orderable="false">Komentarz</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="false">Pesel</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="false">Adres</th>
+              <th data-visible="false" data-searchable="true"  data-orderable="false">Numer telefonu</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Rozmiar Koszulki</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Przyjazdu</th>
+              <th data-visible="false" data-searchable="false" data-orderable="true">Data Wyjazdu</th>
             </tr>
           </thead>
           <tbody>
@@ -141,28 +141,6 @@
                 }
            },
         ],
-        "columnDefs": [
-          {
-            "orderable": false,
-            targets: [0, 12, 14]
-          },
-          {
-            visible: true,
-            targets: [0, 1, 3, 7, 10, 11]
-          },
-          {
-            visible: false,
-            targets: "_all"
-          },
-          {
-            "searchable": true,
-            targets: [1, 4, 5, 12, 14]
-          },
-          {
-            "searchable": false,
-            targets: "_all"
-          }
-          ],
         "language": {
           "url": "{% static 'datatables/Polish.json' %}",
         },
@@ -170,7 +148,6 @@
           $("td:first", nRow).html(iDisplayIndex +1);
           return nRow;
         },
-        "order": [[ 1, "desc" ], [ 11, "desc" ]],
       });
     }
     );

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -8,7 +8,7 @@
     <article class="col-sm-12 maincontent">
       <h1>Wszyscy uczestnicy</h1>
       <div class="table-responsive">
-        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 1, "desc" ], [ 11, "desc" ]]'>
+        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 11, "desc" ], [ 1, "asc" ]]'>
           <thead>
             <tr>
               <th data-visible="true"  data-searchable="false" data-orderable="false"></th>

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -37,12 +37,12 @@
               <tr>
                 <td>
                 </td>
-                <td>
+                <td data-order="{{ person.user.last_name }} {{ person.user.first_name }}">
                   <a href="{% url 'profile' person.user.id %}">
                     {{ person.user.get_full_name | question_mark_on_empty_string }}
                   </a>
                 </td>
-                <td>
+                <td data-order="{{ person.birth | date:"U" }}">
                   {{ person.birth | question_mark_on_none_value }}
                 </td>
                 <td>
@@ -89,10 +89,10 @@
                 <td>
                   {{ person.tshirt_size }}
                 </td>
-                <td>
+                <td data-order="{{ person.start_date | date:"U" }}">
                   {{ person.start_date }}
                 </td>
-                <td>
+                <td data-order="{{ person.end_date | date:"U" }}">
                   {{ person.end_date }}
                 </td>
               </tr>

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -57,7 +57,7 @@
                 <td>
                   {{ person.matura_exam_year | question_mark_on_none_value }}
                 </td>
-                <td>
+                <td data-order="{{ person.points | floatformat }}">
                   <a tabindex="0" data-html="true" role="button" data-trigger="focus" data-toggle="popover" data-placement="bottom" title="Komentarze" data-content="<ul>{% for info in person.infos %} <li> {{ info }} </li> {% endfor %}</ul>">
                     {{ person.points | floatformat }}%
                   </a>
@@ -142,9 +142,6 @@
            },
         ],
         "columnDefs": [
-          {
-            "type": "percent", targets: 4
-          },
           {
             "orderable": false,
             targets: [0, 12, 14]

--- a/templates/workshoplist.html
+++ b/templates/workshoplist.html
@@ -110,7 +110,7 @@
 {% block script %}
   <script>
   $(document).ready( function () {
-    const table = $('#workshop_list').DataTable({
+    const table = $('.workshop-table').DataTable({
       dom: 'Bfrti',
       responsive: true,
       colReorder: true,

--- a/templates/workshoplist.html
+++ b/templates/workshoplist.html
@@ -8,20 +8,20 @@
       {% for entry in workshops %}
         <h2>{{ entry.year }}</h2>
         <div class="table-responsive">
-          <table id="workshop_list" class="table" style="width:100%!important;">
+          <table id="workshop_list" class="table" style="width:100%!important;" data-order='[[ 10, "desc" ]]'>
             <thead>
             <tr>
-              <th></th>
-              <th>Warsztaty</th>
-              <th>Prowadzący</th>
-              <th>Kategorie</th>
-              <th>Rodzaj</th>
-              <th data-toggle="tooltip" data-container="body" data-placement="top" title="Liczba zakwalifikowanych">L.zak.</th>
-              <th data-toggle="tooltip" data-container="body" data-placement="top" title="Liczba zapisanych">L.zap.</th>
-              <th data-toggle="tooltip" data-container="body" data-placement="top" title="Próg kwalifikacji ustawiony?">Próg?</th>
-              <th data-toggle="tooltip" data-container="body" data-placement="top" title="Zadania opublikowane?">Zadania?</th>
-              <th data-toggle="tooltip" data-container="body" data-placement="top" title="Strona opublikowana?">Strona?</th>
-              <th>Status</th>
+              <th data-visible="true" data-searchable="false" data-orderable="false"></th>
+              <th data-visible="true" data-searchable="true"  data-orderable="true">Warsztaty</th>
+              <th data-visible="true" data-searchable="true"  data-orderable="true">Prowadzący</th>
+              <th data-visible="true" data-searchable="true"  data-orderable="true">Kategorie</th>
+              <th data-visible="true" data-searchable="true"  data-orderable="true">Rodzaj</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true" data-toggle="tooltip" data-container="body" data-placement="top" title="Liczba zakwalifikowanych">L.zak.</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true" data-toggle="tooltip" data-container="body" data-placement="top" title="Liczba zapisanych">L.zap.</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true" data-toggle="tooltip" data-container="body" data-placement="top" title="Próg kwalifikacji ustawiony?">Próg?</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true" data-toggle="tooltip" data-container="body" data-placement="top" title="Zadania opublikowane?">Zadania?</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true" data-toggle="tooltip" data-container="body" data-placement="top" title="Strona opublikowana?">Strona?</th>
+              <th data-visible="true" data-searchable="false" data-orderable="true">Status</th>
             </tr>
             </thead>
             <tbody>
@@ -142,24 +142,6 @@
           }
         },
       ],
-      "columnDefs": [
-        {
-          "orderable": false,
-          targets: [0]
-        },
-        {
-          visible: true,
-          targets: "_all"
-        },
-        {
-          "searchable": true,
-          targets: [1, 2, 3, 4]
-        },
-        {
-          "searchable": false,
-          targets: "_all"
-        }
-        ],
       "language": {
         "url": "{% static 'datatables/Polish.json' %}",
       },
@@ -167,7 +149,6 @@
         $("td:first", nRow).html(iDisplayIndex +1);
         return nRow;
       },
-      "order": [[ 10, "desc" ]],
     });
   });
 

--- a/templates/workshoplist.html
+++ b/templates/workshoplist.html
@@ -8,7 +8,7 @@
       {% for entry in workshops %}
         <h2>{{ entry.year }}</h2>
         <div class="table-responsive">
-          <table id="workshop_list" class="table" style="width:100%!important;" data-order='[[ 10, "desc" ]]'>
+          <table class="table workshop-table" style="width:100%!important;" data-order='[[ 10, "desc" ]]'>
             <thead>
             <tr>
               <th data-visible="true" data-searchable="false" data-orderable="false"></th>
@@ -108,7 +108,7 @@
 {% block script %}
   <script>
   $(document).ready( function () {
-    const table = $('#workshop_list').DataTable({
+    const table = $('.workshop-table').DataTable({
       dom: 'Bfrtip',
       responsive: true,
       colReorder: true,

--- a/templates/workshoplist.html
+++ b/templates/workshoplist.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
+
 {% load staticfiles %}
+{% load wwwtags %}
 
 {% block content %}
   <div class="container">
@@ -40,9 +42,9 @@
                       <a href="{% url 'workshop' workshop.name %}">{{ workshop.title }}</a>
                     {% endif %}
                   </td>
-                  <td>
+                  <td data-order="{% for lecturer in workshop.lecturer.all %}{{ lecturer.user.last_name }} {{ lecturer.user.first_name }} {% endfor %}">
                     {% for lecturer in workshop.lecturer.all %}
-                      <a href="{% url 'profile' lecturer.user.id %}">{{ lecturer.user.first_name }} {{ lecturer.user.last_name }}</a><br/>
+                      <a href="{% url 'profile' lecturer.user.id %}">{{ lecturer.user.get_full_name | question_mark_on_empty_string }}</a><br/>
                     {% endfor %}
                   </td>
                   <td>


### PR DESCRIPTION
This fixes all bugs in datatables that were found so far.

* Sorting by number of points now works (closes #78)
* Tables for previous years in workshop list now work (closes #84)
* The default sorting settings are now something sensible (previous were by "Comment" field for lecuturers and names IN REVERSE ORDER for participants :man_facepalming: - closes #85, I didn't even realize how bad it was when reporting it)
* Sorting by dates now works
* Sorting by names will now sort by last names rather than first names
* Sorting names with Polish characters now works as expected, rather than putting them always at the end
* Column parameters are now specified in HTML rather than by index which should help avoid bugs if we ever add/remove columns