### PR TITLE
Prevent TinyMCE from stealing global jQuery object and don't include a second copy

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -23,6 +23,11 @@
             {% csrf_token %}
             {% block script %}
               {{ block.super }}
+
+              <script>
+              /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+              var django = {jQuery: jQuery};
+              </script>
               {{ form.media }}
             {% endblock %}
             {{ form.as_p }}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -208,6 +208,11 @@
 
 {% block script %}
   {{ block.super }}
+
+  <script>
+  /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+  var django = {jQuery: jQuery};
+  </script>
   {{ user_profile_page_form.media }}
   {{ user_cover_letter_form.media }}
 

--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -13,6 +13,11 @@
             {% csrf_token %}
             {% block script %}
               {{ block.super }}
+
+              <script>
+              /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+              var django = {jQuery: jQuery};
+              </script>
               {{ form.media }}
             {% endblock %}
             {{ form | crispy }}

--- a/templates/workshoppage.html
+++ b/templates/workshoppage.html
@@ -40,6 +40,11 @@
               {% csrf_token %}
               {% block script %}
                 {{ block.super }}
+
+                <script>
+                /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+                var django = {jQuery: jQuery};
+                </script>
                 {{ form.media }}
               {% endblock %}
               {{ form | crispy }}

--- a/wwwapp/settings.py
+++ b/wwwapp/settings.py
@@ -220,6 +220,7 @@ TEMPLATES = [
 
 TINYMCE_JS_URL = os.path.join(STATIC_URL, "tinymce/js/tinymce/tinymce.min.js")
 TINYMCE_JS_ROOT = os.path.join(STATIC_URL, "tinymce/js/tinymce")
+TINYMCE_INCLUDE_JQUERY = False
 TINYMCE_DEFAULT_CONFIG = {
     'theme': 'silver',
     'plugins': 'preview paste searchreplace autolink code visualblocks visualchars image link media codesample table charmap hr nonbreaking anchor toc advlist lists wordcount imagetools textpattern quickbars emoticons',


### PR DESCRIPTION
This fixes a bug that caused random things to blow up when TinyMCE was included on the page.

Closes #118.