### PR TITLE
Disable TinyMCE image paste/editing where uploads are not supported

### DIFF
--- a/wwwapp/forms.py
+++ b/wwwapp/forms.py
@@ -128,10 +128,9 @@ class ArticleForm(ModelForm):
         super(ModelForm, self).__init__(*args, **kwargs)
         mce_attrs = {}
         if kwargs['instance']:
+            mce_attrs = settings.TINYMCE_DEFAULT_CONFIG_WITH_IMAGES.copy()
             mce_attrs['automatic_uploads'] = True
             mce_attrs['images_upload_url'] = reverse('upload', kwargs={'type': 'article', 'name': kwargs['instance'].name})
-            mce_attrs['file_picker_types'] = 'image'
-            mce_attrs['file_picker_callback'] = 'tinymce_local_file_picker'
         self.fields['content'].widget = TinyMCE(mce_attrs=mce_attrs)
         if not user.has_perm('wwwapp.can_put_on_menubar'):
             del self.fields['on_menubar']
@@ -184,10 +183,9 @@ class WorkshopPageForm(ModelForm):
         super(ModelForm, self).__init__(*args, **kwargs)
         mce_attrs = {}
         if kwargs['instance']:
+            mce_attrs = settings.TINYMCE_DEFAULT_CONFIG_WITH_IMAGES.copy()
             mce_attrs['automatic_uploads'] = True
             mce_attrs['images_upload_url'] = reverse('upload', kwargs={'type': 'workshop', 'name': kwargs['instance'].name})
-            mce_attrs['file_picker_types'] = 'image'
-            mce_attrs['file_picker_callback'] = 'tinymce_local_file_picker'
         self.fields['page_content'].widget = TinyMCE(mce_attrs=mce_attrs)
 
 

--- a/wwwapp/settings.py
+++ b/wwwapp/settings.py
@@ -222,9 +222,9 @@ TINYMCE_JS_URL = os.path.join(STATIC_URL, "tinymce/js/tinymce/tinymce.min.js")
 TINYMCE_JS_ROOT = os.path.join(STATIC_URL, "tinymce/js/tinymce")
 TINYMCE_DEFAULT_CONFIG = {
     'theme': 'silver',
-    'plugins': 'preview paste searchreplace autolink code visualblocks visualchars image link media codesample table charmap hr nonbreaking anchor toc advlist lists wordcount imagetools textpattern quickbars emoticons',
+    'plugins': 'preview paste searchreplace autolink code visualblocks visualchars image link media codesample table charmap hr nonbreaking anchor toc advlist lists wordcount textpattern emoticons',
     'removed_menuitems': 'newdocument',
-    'toolbar': 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent | numlist bullist | image media link codesample',
+    'toolbar': 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent | numlist bullist | link',
     'content_css': [
         '/static/css/bootstrap.min.css',
         '/static/css/main.css',
@@ -233,10 +233,17 @@ TINYMCE_DEFAULT_CONFIG = {
     'height': 500,
     'branding': False,
     'image_advtab': True,
-    'paste_data_images': True,
+    'paste_data_images': False,
     'relative_urls': False,
     'remove_script_host': True,
     'link_list': '/articleNameList/',
+}
+TINYMCE_DEFAULT_CONFIG_WITH_IMAGES = {  # Additional settings for editors where image upload is allowed
+    'plugins': 'preview paste searchreplace autolink code visualblocks visualchars image link media codesample table charmap hr nonbreaking anchor toc advlist lists wordcount imagetools textpattern quickbars emoticons',
+    'toolbar': 'undo redo | bold italic underline strikethrough | fontselect fontsizeselect formatselect | alignleft aligncenter alignright alignjustify | outdent indent | numlist bullist | image media link codesample',
+    'paste_data_images': True,
+    'file_picker_types': 'image',
+    'file_picker_callback': 'tinymce_local_file_picker',
 }
 
 CURRENT_YEAR = 2019


### PR DESCRIPTION
When image uploads are not supported (profile page, cover letter, workshop proposal, article before it's saved for the first time) the image upload features are disabled by:
* removing plugins: imagetools (in-browser image editing), quickbars (the upload image/add table buttons that appear when cursor is on an empty line)
* not adding automatic_uploads, images_upload_url (obviously - additionally disables the upload dialog in Insert > Image)
* disabling paste_data_images (no ctrl+v of images)
* disabling file_picker_* (no additional upload button in Insert > Image dialog next to the file path)
* removing the add image button from toolbar (still available under Insert > Image)
* no drag-and-drop of images (not actually sure which of the above disabled that but something did XD)

Note that it is still possible to add images from external URLs, just not upload.

The editors where image uploads are supported (workshop public page, article) should be unaffected.

Closes #116