### PR TITLE
Clean up all extra copies of <form> tags, CSRF tokens and TinyMCE scripts

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -22,20 +22,21 @@
           <hr>
           <form action="" method="post">
             {% csrf_token %}
-            {% block script %}
-              {{ block.super }}
-
-              <script>
-              /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
-              var django = {jQuery: jQuery};
-              </script>
-              {{ form.media }}
-            {% endblock %}
-            {{ form | crispy }}
+            {% crispy form %}
             <button class="btn btn-default">Zapisz</button>
           </form>
         </div>
       {% endif %}
     </article>
   </div>
+{% endblock %}
+
+{% block script %}
+  {{ block.super }}
+
+  <script>
+  /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+  var django = {jQuery: jQuery};
+  </script>
+  {{ form.media }}
 {% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -16,6 +16,7 @@
             <form id="profile_data_form" action="#data" method="post" class="form-horizontal">
               <input type="hidden" name="page" value="data">
               {% include "_profilesubmit.html" %}
+              {% csrf_token %}
               {% crispy user_form %}
               {% crispy user_profile_form %}
             </form>
@@ -25,7 +26,7 @@
               <input type="hidden" name="page" value="profile_page">
               {% csrf_token %}
               {% include "_profilesubmit.html" %}
-              {{ user_profile_page_form.profile_page }}
+              {% crispy user_profile_page_form %}
             </form>
           </div>
           <div title="List motywacyjny" id="cover_letter">
@@ -59,7 +60,7 @@
               <input type="hidden" name="page" value="cover_letter">
               {% csrf_token %}
               <button class="btn btn-default big-button">Zapisz</button>
-              {{ user_cover_letter_form.cover_letter }}
+              {% crispy user_cover_letter_form %}
             </form>
           </div>
           <div title="Informacje" id="user_info">
@@ -68,7 +69,6 @@
               {% csrf_token %}
               <button class="btn btn-default big-button">Zapisz</button>
               {% crispy user_info_page_form %}
-
             </form>
           </div>
         </div>
@@ -213,8 +213,11 @@
   /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
   var django = {jQuery: jQuery};
   </script>
+  {{ user_form.media }}
+  {{ user_profile_form.media }}
   {{ user_profile_page_form.media }}
   {{ user_cover_letter_form.media }}
+  {{ user_info_page_form.media }}
 
   <script>
     $(document).ready(function() {

--- a/templates/workshop.html
+++ b/templates/workshop.html
@@ -11,16 +11,7 @@
         <div role="tabpanel">
           <form action="" method="post">
             {% csrf_token %}
-            {% block script %}
-              {{ block.super }}
-
-              <script>
-              /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
-              var django = {jQuery: jQuery};
-              </script>
-              {{ form.media }}
-            {% endblock %}
-            {{ form | crispy }}
+            {% crispy form %}
             <button class="btn btn-default">Zapisz</button>
           </form>
         </div>
@@ -29,4 +20,14 @@
       {% endif %}
     </article>
   </div>
+{% endblock %}
+
+{% block script %}
+  {{ block.super }}
+
+  <script>
+  /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+  var django = {jQuery: jQuery};
+  </script>
+  {{ form.media }}
 {% endblock %}

--- a/templates/workshoppage.html
+++ b/templates/workshoppage.html
@@ -38,16 +38,7 @@
           <div role="tabpanel" style="margin: 1em 0;">
             <form action="" method="post" enctype="multipart/form-data">
               {% csrf_token %}
-              {% block script %}
-                {{ block.super }}
-
-                <script>
-                /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
-                var django = {jQuery: jQuery};
-                </script>
-                {{ form.media }}
-              {% endblock %}
-              {{ form | crispy }}
+              {% crispy form %}
               <button class="btn btn-default">Zapisz</button>
             </form>
           </div>
@@ -64,4 +55,14 @@
       {% endif %}
     </article>
   </div>
+{% endblock %}
+
+{% block script %}
+  {{ block.super }}
+
+  <script>
+  /* Fixes a bug in django-tinymce with TINYMCE_INCLUDE_JQUERY = False, see https://github.com/aljosa/django-tinymce/issues/234 */
+  var django = {jQuery: jQuery};
+  </script>
+  {{ form.media }}
 {% endblock %}

--- a/wwwapp/forms.py
+++ b/wwwapp/forms.py
@@ -16,6 +16,13 @@ from .widgets import RenderHTML
 
 
 class UserProfilePageForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(UserProfilePageForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
+
     class Meta:
         model = UserProfile
         fields = ['profile_page']
@@ -24,6 +31,13 @@ class UserProfilePageForm(ModelForm):
 
 
 class UserCoverLetterForm(ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(UserCoverLetterForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
+
     class Meta:
         model = UserProfile
         fields = ['cover_letter']
@@ -35,6 +49,9 @@ class UserInfoPageForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(UserInfoPageForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         self.helper.label_class = 'col-lg-3'
         self.helper.field_class = 'col-lg-9'
 
@@ -82,6 +99,9 @@ class UserProfileForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(UserProfileForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         self.helper.label_class = 'col-lg-2'
         self.helper.field_class = 'col-lg-10'
     
@@ -100,6 +120,9 @@ class UserForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super(UserForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         self.helper.label_class = 'col-lg-2'
         self.helper.field_class = 'col-lg-10'
 
@@ -126,6 +149,10 @@ class ArticleForm(ModelForm):
 
     def __init__(self, user, *args, **kwargs):
         super(ModelForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         mce_attrs = {}
         if kwargs['instance']:
             mce_attrs = settings.TINYMCE_DEFAULT_CONFIG_WITH_IMAGES.copy()
@@ -146,6 +173,10 @@ class WorkshopForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(WorkshopForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         if self.instance.status:
             self.fields['proposition_description'].disabled = True
             self.fields['proposition_description'].widget = RenderHTML()
@@ -181,6 +212,10 @@ class WorkshopPageForm(ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(ModelForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.include_media = False
         mce_attrs = {}
         if kwargs['instance']:
             mce_attrs = settings.TINYMCE_DEFAULT_CONFIG_WITH_IMAGES.copy()


### PR DESCRIPTION
Either somebody didn't notice how generous crispy forms is with adding things, or this changed during the upgrade we did a while ago and nobody noticed. I'm actually suprised this even worked given what was going on in the HTML.

And putting blocks inside blocks makes your content appear twice. This didn't help either.

Closes #133