### PR TITLE
Fix download_remote_images

### DIFF
--- a/wwwapp/management/commands/download_remote_images.py
+++ b/wwwapp/management/commands/download_remote_images.py
@@ -40,6 +40,8 @@ class Command(BaseCommand):
     def update_description(text, path, dryrun):
         def update_img(m):
             url = m.group(1)
+            if not url.startswith("http://") and not url.startswith("https://"):
+                return m.group(0)
             print("Downloading {}".format(url))
             r = requests.get(url)
             if r.status_code != 200:

--- a/wwwapp/management/commands/download_remote_images.py
+++ b/wwwapp/management/commands/download_remote_images.py
@@ -46,7 +46,11 @@ class Command(BaseCommand):
                 print("WARNING: {} returned {}".format(url, r.status_code))
                 return m.group(0)
             else:
-                ext = mimetypes.guess_extension(r.headers['Content-Type'])
+                if 'Content-Type' not in r.headers:
+                    raise Exception("Server didn't provide a Content-Type for the file")
+                ext = mimetypes.guess_extension(r.headers['Content-Type'].split(";")[0])
+                if ext is None:
+                    raise Exception("Unable to determine file extension for " + r.headers['Content-Type'])
                 fname = hashlib.sha256(r.content).hexdigest() + ext
                 fpath = os.path.join(settings.MEDIA_ROOT, path, fname)
                 print("Saving to {}".format(fpath))


### PR DESCRIPTION
It broke when the server provided Content-Type like `image/jpeg; charset=utf-8` (who needs charset for images?) and when the images were already local (oops, my bad)

I hope now it can run through all images on production database, but let me know if it breaks anywhere else

Closes #134