### PR TITLE
Fix program page layout on mobile devices

### DIFF
--- a/templates/_programworkshop.html
+++ b/templates/_programworkshop.html
@@ -1,17 +1,19 @@
 <div class="col-sm-2 text-center button-div">
   {% if registered %}
-  <a onclick="handle_registration_change('{{ workshop.name }}', false);">
-    <button class="btn btn-warning btn-circle btn-m" type="button"><i class="glyphicon glyphicon-minus"></i></button>
-    </br>
+  <div onclick="handle_registration_change('{{ workshop.name }}', false);" style="cursor: pointer;">
+    <button class="btn btn-warning btn-circle btn-m" type="button">
+      <i class="glyphicon glyphicon-minus"></i>
+    </button>
+    <br/>
     <h4 class="text-default">Wypisz się</h4>
-  </a>
+  </div>
   {% else %}
-  <a onclick="handle_registration_change('{{ workshop.name }}', true);">
+  <div onclick="handle_registration_change('{{ workshop.name }}', true);" style="cursor: pointer;">
     <button class="btn btn-success btn-circle btn-m" type="button">
       <i class="glyphicon glyphicon-plus"></i>
     </button>
-    </br>
+    <br/>
     <h4 class="text-default">Zapisz się</h4>
-  </a>
+  </div>
   {% endif %}
 </div>

--- a/templates/program.html
+++ b/templates/program.html
@@ -79,20 +79,22 @@
       <div class="panel-group">
         {% for workshop, registered in workshops %}
           <div class="panel panel-default" id="{{ workshop.name }}">
-            <div class="panel-heading" style="font-size: 16pt;">
-              {% if workshop.page_content_is_public %}
-                {% if workshop.status == 'X' %}(ODWOŁANE) {% endif %}
-                <a href="{% url 'workshop_page' workshop.name %}"><span class="big">{{ workshop.title }}</span></a>
-              {% else %}
+            <div class="panel-heading row" style="font-size: 16pt;">
+              <div class="col-sm-8">
+                {% if workshop.page_content_is_public %}
+                  {% if workshop.status == 'X' %}(ODWOŁANE) {% endif %}
+                  <a href="{% url 'workshop_page' workshop.name %}"><span class="big">{{ workshop.title }}</span></a>
+                {% else %}
                   <span class="big">{{ workshop.title }}</span>
-              {% endif %}
-                <span class="pull-right">
-                  <span class="big">
-                    {% for lecturer in workshop.lecturer.all %}
-                      <a href="{% url 'profile' lecturer.user.id %}">{{ lecturer }}</a>{% if not forloop.last %},{% endif %}
-                    {% endfor %}
+                {% endif %}
+              </div>
+              <div class="col-sm-4 text-right">
+                {% for lecturer in workshop.lecturer.all %}
+                  <span style="display: inline-block;"> <!-- this makes it so that line breaks are preferred at the point of the comma, not in the middle of the name -->
+                    <a href="{% url 'profile' lecturer.user.id %}">{{ lecturer }}</a>{% if not forloop.last %},{% endif %}
                   </span>
-                </span>
+                {% endfor %}
+              </div>
             </div>
             <div class="panel-body" style="margin-bottom: -20px">
               <div class="col-sm-2 hidden-xs">


### PR DESCRIPTION
* Make sure the lecturer name does not move outside the header background
* Force the lecturer name onto next line on mobile devices where there is not much horizontal space
* Force equal amounts of space for names and lecturers for a more table-like layout
* In lecturer name lists, prefer a line break between the names rather than in the middle of the name
* Make the register/unregister button a div to make it still work if you happen to click in between the actual button and the text below and fix mouse cursor on the link

![Screenshot_20200309-230348_Chrome](https://user-images.githubusercontent.com/1517255/76261493-6fc54780-625a-11ea-8146-12fed43f5f80.jpg)
![image](https://user-images.githubusercontent.com/1517255/76261606-a8fdb780-625a-11ea-8a63-b36b80b481c1.png)

Closes #154