### PR TITLE
Make sure negative points don't break the percentage system

### DIFF
--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -355,7 +355,7 @@ class WorkshopParticipant(models.Model):
         max_points = self.workshop.max_points
         if max_points is None:
             max_points = self.workshop.workshopparticipant_set.aggregate(max_points=models.Max('qualification_result'))['max_points']
-        return min(self.qualification_result / max_points * 100, settings.MAX_POINTS_PERCENT)
+        return max(min(self.qualification_result / max_points * 100, settings.MAX_POINTS_PERCENT), 0)
 
     class Meta:
         unique_together = [('workshop', 'participant')]

--- a/wwwapp/settings.py
+++ b/wwwapp/settings.py
@@ -273,4 +273,5 @@ INTERNAL_IPS = [
 
 # Max amount of points that a participant can get during qualification (relative to configured max_points for a given workshop)
 # This allows to give some people bonus points above 100%
+# Note that this is not a hard limit for values that can be entered by lecturers, excessive values will just be clamped for percentage calculation
 MAX_POINTS_PERCENT = 200


### PR DESCRIPTION
This works similarly to MAX_POINTS_PERCENT - you can give below 0 points, but the score will be clamped for percentage calculation

Closes #177