### PR TITLE
Fix image resize

### DIFF
--- a/wwwapp/settings.py
+++ b/wwwapp/settings.py
@@ -134,7 +134,7 @@ BLEACH_ALLOWED_TAGS = [
 # Which HTML attributes are allowed
 BLEACH_ALLOWED_ATTRIBUTES = [
     'href', 'title', 'style', 'alt', 'src', 'dir', 'class', 'border', 'cellpadding', 'cellspacing', 'id',
-    'name', 'align',
+    'name', 'align', 'width', 'height',
 ]
 
 # Which CSS properties are allowed in 'style' attributes (assuming


### PR DESCRIPTION
The new editor uses width and height attributes instead of CSS styles

Closes #183