### PR TITLE
Add workaround for broken non-responsive Facebook widget

### DIFF
--- a/static/js/warsztatywww.js
+++ b/static/js/warsztatywww.js
@@ -161,4 +161,21 @@ $(function () {
             enabledDates: dates,
         });
     });
+
+    // Facebook fix your sh*t (╯°□°)╯︵ ┻━┻
+    function fixBrokenUnresponsiveFacebook() {
+        $('iframe').each(function() {
+            var url = $(this).attr('src');
+            if (url.indexOf('facebook.com/plugins/page.php') === -1)
+                return;
+            if($(this).width() == 0 || $(this).height() == 0)
+                return;
+            url = url.replace(/width=([0-9]+)/, 'width=' + $(this).width());
+            url = url.replace(/height=([0-9]+)/, 'height=' + $(this).height());
+            if ($(this).attr('src') != url)
+                $(this).attr('src', url);
+        });
+    }
+    fixBrokenUnresponsiveFacebook();
+    $(window).resize(fixBrokenUnresponsiveFacebook);
 });

--- a/wwwapp/settings.py
+++ b/wwwapp/settings.py
@@ -140,7 +140,8 @@ BLEACH_ALLOWED_ATTRIBUTES = [
 # Which CSS properties are allowed in 'style' attributes (assuming
 # style is an allowed attribute)
 BLEACH_ALLOWED_STYLES = [
-    'font-family', 'font-weight', 'text-decoration', 'font-variant', 'float', 'height', 'width',
+    'font-family', 'font-weight', 'text-decoration', 'font-variant', 'float',
+    'height', 'width', 'min-height', 'min-width', 'max-height', 'max-width',
     'margin', 'margin-top', 'margin-bottom', 'margin-right', 'margin-left',
     'padding', 'padding-top', 'padding-bottom', 'padding-left', 'padding-right',
     'text-align', 'title', 'page-break-after', 'display', 'color', 'background-color',


### PR DESCRIPTION
It has an adapt_container_width option but it doesn't work. All online resources say to just do this. I quit (╯°□°)╯︵ ┻━┻

Expected usage:
```html
<div class="row">
    <div class="col-md-8 col-xs-12">
        <p>Some content...</p>
    </div>
    </div>
    <div class="col-md-4 hidden-sm hidden-xs" style="text-align: center;">
        <iframe style="border: none; width: 100%; min-width: 180px; max-width: 500px;" src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fwarsztatywww%2F&amp;tabs=timeline&amp;width=340&amp;height=500&amp;small_header=false&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1522345984699744" height="500"></iframe>
    </div>
    <div class="col-xs-12 hidden-md hidden-lg hidden-xl" style="text-align: center;">
        <iframe style="border: none; width: 100%; min-width: 180px; max-width: 500px;" src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fwarsztatywww%2F&amp;tabs&amp;width=500&amp;height=214&amp;small_header=false&amp;adapt_container_width=true&amp;hide_cover=false&amp;show_facepile=true&amp;appId=1522345984699744" height="214"></iframe>
    </div>
</div>
```