### PR TITLE
Add 'all people' tab

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -94,6 +94,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="{% url 'participants' %}">Uczestnicy</a></li>
                   <li><a href="{% url 'lecturers' %}">Prowadzący</a></li>
+                  <li><a href="{% url 'all_people' %}">Wszyscy ludzie</a></li>
                   <li><a href="{% url 'filter_emails' %}">Adresy email</a></li>
                   {% if request.user.is_staff %}
                     <li role="separator" class="divider"></li>

--- a/templates/lecturers.html
+++ b/templates/lecturers.html
@@ -6,7 +6,7 @@
 {% block content %}
   <div class="container">
     <article class="col-sm-12 maincontent">
-      <h1>Wszyscy prowadzący</h1>
+      <h1>{{ title }}</h1>
       <div class="table-responsive">
         <table id="lecturers-table" class="table" style="width:100%!important;" data-order='[[ 1, "asc" ]]'>
           <thead>

--- a/templates/participants.html
+++ b/templates/participants.html
@@ -7,29 +7,31 @@
 {% block content %}
   <div class="container">
     <article class="col-sm-12 maincontent">
-      <h1>Wszyscy uczestnicy</h1>
+      <h1>{{ title }}</h1>
       <div class="table-responsive">
-        <table id="participants-table" class="table" style="width:100%!important;" data-order='[[ 11, "desc" ], [ 1, "asc" ]]'>
+        <table id="participants-table" class="table" style="width:100%!important;" data-order='{% if is_all_people %}[[ 1, "asc" ]]{% else %}[[ 11, "desc" ], [ 1, "asc" ]]{% endif %}'>
           <thead>
             <tr>
               <th data-visible="true"  data-searchable="false" data-orderable="false"></th>
               <th data-visible="true"  data-searchable="true"  data-orderable="true">Imię i nazwisko</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Data Urodzenia</th>
-              <th data-visible="true"  data-searchable="false" data-orderable="true">Pełnoletni</th>
-              <th data-visible="false" data-searchable="true"  data-orderable="true">Email</th>
+              <th data-visible="{% if is_all_people %}false{% else %}true{% endif %}" data-searchable="false" data-orderable="true">Pełnoletni</th>
+              <th data-visible="{% if is_all_people %}true{% else %}false{% endif %}" data-searchable="true"  data-orderable="true">Email</th>
               <th data-visible="false" data-searchable="true"  data-orderable="true">Szkoła</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Rok Matury</th>
+              {% if not is_all_people %}
               <th data-visible="true"  data-searchable="false" data-orderable="true">Punkty</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Suma ilości warsztatów</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Ilość Zakwalifikowanych Warsztatów</th>
               <th data-visible="true"  data-searchable="false" data-orderable="true">List motywacyjny</th>
               <th data-visible="true"  data-searchable="false" data-orderable="true">Status</th>
+              {% endif %}
               <th data-visible="true"  data-searchable="false" data-orderable="true">Poprzednie edycje</th>
               <th data-visible="false" data-searchable="false" data-orderable="false">Skąd wiesz o WWW?</th>
               <th data-visible="false" data-searchable="false" data-orderable="false">Komentarz</th>
               <th data-visible="false" data-searchable="true"  data-orderable="false">Pesel</th>
               <th data-visible="false" data-searchable="true"  data-orderable="false">Adres</th>
-              <th data-visible="false" data-searchable="true"  data-orderable="false">Numer telefonu</th>
+              <th data-visible="{% if is_all_people %}true{% else %}false{% endif %}" data-searchable="true"  data-orderable="false">Numer telefonu</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Rozmiar Koszulki</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Data Przyjazdu</th>
               <th data-visible="false" data-searchable="false" data-orderable="true">Data Wyjazdu</th>
@@ -60,6 +62,7 @@
                 <td>
                   {{ person.matura_exam_year | question_mark_on_none_value }}
                 </td>
+                {% if not is_all_people %}
                 <td data-order="{{ person.points | unlocalize }}">
                   <a tabindex="0" data-html="true" role="button" data-trigger="focus" data-toggle="popover" data-placement="bottom" title="Komentarze" data-content="<ul>{% for info in person.infos %} <li> {{ info }} </li> {% endfor %}</ul>">
                     {{ person.points | floatformat }}%
@@ -83,6 +86,7 @@
                     {{ person.status_display|default_if_none:"Brak" }}
                   {% endif %}
                 </td>
+                {% endif %}
                 <td data-order="{% for participation in person.participation_data reversed %}{{ participation.year }}:{% if participation.workshops %}2{% elif participation.status == 'Z' %}1{% else %}0{% endif %} {% endfor %}">
                     {% include '_pastParticipation.html' with participation_data=person.participation_data only %}
                 </td>

--- a/wwwapp/urls.py
+++ b/wwwapp/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     url(r'^([0-9]+)/participants/$', views.participants_view, name='year_participants'),
     url(r'^lecturers/$', RedirectView.as_view(url='/%d/lecturers/' % settings.CURRENT_YEAR, permanent=False), name='lecturers'),
     url(r'^([0-9]+)/lecturers/$', views.lecturers_view, name='year_lecturers'),
+    url(r'^people/$', views.participants_view, name='all_people'),
     url(r'^emails/$', views.emails_view, name='emails'),
     url(r'^filterEmails/(?:(?P<year>[0-9]+)/(?P<filter_id>[a-zA-Z0-9\-_]+)/)?$', mail_views.filtered_emails_view, name='filter_emails'),
     url(r'^template_for_workshop_page/$', views.template_for_workshop_page_view, name='template_for_workshop_page'),


### PR DESCRIPTION
This adds an all people tab which displays everybody who is registered in the system.
This is very similar to the participants table, except that it also shows lecturers, is not filtered by year, and displays different columns by default.
Note that a visible by default 'years this user participated in' column will be added by #203

Closes #88

(Perhaps this should target `future`? Depends if you think it would be useful now or not. I couldn't change it while creating the pull request because I made it on `master` initially and `future` is missing some commits from `master`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/204)
<!-- Reviewable:end -->
