### PR TITLE
Removed version specification in gallery/serup.py

### DIFF
--- a/gallery/setup.py
+++ b/gallery/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
-requirements = ['django-imagekit==4.0.2', 'Pillow==6.2.1']
+requirements = ['django-imagekit', 'Pillow']
 
 setup(
     name='django-starcross-gallery',


### PR DESCRIPTION
We don't use setup.py and Github complains about versions with known vulnerabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/222)
<!-- Reviewable:end -->
