### PR TITLE
Fix missed occurrence of the workshop URL name

### DIFF
--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -239,7 +239,7 @@ def workshop_proposal_view(request, name=None):
                     workshop.lecturer.add(user_profile)
                     workshop.save()
                 messages.info(request, 'Zapisano.')
-                return redirect('workshop', form.instance.name)
+                return redirect('workshop_proposal', form.instance.name)
         else:
             form = WorkshopForm(instance=workshop)
     else:


### PR DESCRIPTION
> I encountered following error when creating a workshop proposal
> ```
> NoReverseMatch at /addWorkshop/
> 
> Reverse for 'workshop' not found. 'workshop' is not a valid view function or pattern name.
> ...
> wwwapp/views.py, line 241, in workshop_proposal_view 
> ```

I missed one place during rename in 76bd241a5b56abce835d9c346a593a7a0bd700f2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/226)
<!-- Reviewable:end -->
