### PR TITLE
Remove unused emails endpoint

### DIFF
--- a/wwwapp/urls.py
+++ b/wwwapp/urls.py
@@ -49,7 +49,6 @@ urlpatterns = [
     path('lecturers/', RedirectView.as_view(url='/%d/lecturers/' % settings.CURRENT_YEAR, permanent=False), name='lecturers'),
     path('<int:year>/lecturers/', views.lecturers_view, name='year_lecturers'),
     path('people/', views.participants_view, name='all_people'),
-    path('emails/', views.emails_view, name='emails'),
     path('filterEmails/', mail_views.filtered_emails_view, name='filter_emails'),
     path('filterEmails/<int:year>/<int:filter_id>/', mail_views.filtered_emails_view, name='filter_emails'),
     path('template_for_workshop_page/', views.template_for_workshop_page_view, name='template_for_workshop_page'),

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -742,23 +742,6 @@ def render_workshops(request, title, link_to_edit, workshops):
     return render(request, 'listworkshop.html', context)
 
 
-@login_required()
-@permission_required('wwwapp.see_all_workshops', raise_exception=True)  # Think about seperate permission
-def emails_view(request):
-    workshops = Workshop.objects.all()
-
-    result = []
-    for workshop in workshops:
-        lecturer = workshop.lecturer.all()[0]
-        email = lecturer.user.email
-        name = lecturer.user.first_name + " " + lecturer.user.last_name
-
-        to_append = {'workshopname': workshop.title, 'email': email, 'name': name}
-        result.append(to_append)
-
-    return JsonResponse(result, safe=False)
-
-
 def as_article(name):
     # We want to make sure that article with this name exists.
     # try-except is needed because of some migration/initialization problems.


### PR DESCRIPTION
I'm not sure why it's even here, it was not even properly updated after multiple year support
was added. I guess it was used before filterEmails became a thing? Either way, we don't need it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/244)
<!-- Reviewable:end -->
