### PR TITLE
Optimize some SQL queries

### DIFF
--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -141,7 +141,7 @@ class UserProfile(models.Model):
 
     def workshop_profile_for(self, year: Camp):
         try:
-            return self.workshop_profile.filter(year=year).get()
+            return self.workshop_profile.get(year=year)
         except WorkshopUserProfile.DoesNotExist:
             return None
 

--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -89,8 +89,8 @@ class UserProfile(models.Model):
         """
         Returns the participation data from UserWorkshopProfile joined with data about lectures
         """
-        participant_data = self.workshop_profile.filter(status__isnull=False)
-        lecturer_data = self.lecturer_workshops.filter(status__isnull=False)
+        participant_data = [p for p in self.workshop_profile.all() if p.status is not None]
+        lecturer_data = [p for p in self.lecturer_workshops.all() if p.status is not None]
         years = set([profile.year for profile in participant_data] + [workshop.type.year for workshop in lecturer_data])
         data = []
         for year in sorted(years, key=lambda x: x.year):

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -408,6 +408,8 @@ def participants_view(request, year=None):
         'user_info',
         'workshop_profile',
         'workshop_profile__year',
+        'lecturer_workshops',
+        'lecturer_workshops__type__year',
     ).all()
 
     if year is not None:


### PR DESCRIPTION
Loading of the people list pages is kinda slow, mostly because data for `UserProfile.all_participation_data()` was not prefetched

On my test database (~ 50 people with debug enabled), in the all people view this gives:

SQL queries: 133 -> 27
Total query time: 2770ms -> 823ms

On production, the difference should be even more noticeable (right now, loading the all people page takes almost 4 seconds)

(this will obviously conflict with #230, but oh well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/245)
<!-- Reviewable:end -->
