### PR TITLE
Make the workshop template apply upon clicking save for the first time instead of first editor load

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -99,9 +99,14 @@
                   <li><a href="{% url 'all_people' %}">Wszyscy ludzie</a></li>
                   <li><a href="{% url 'filter_emails' %}">Adresy email</a></li>
                   {% endif %}
-                  {% if request.user.is_staff %}
+                  {% if request.user.is_staff or perms.wwwapp.export_workshop_registration or perms.wwwapp.change_article %}
                     <li role="separator" class="divider"></li>
+                  {% endif %}
+                  {% if request.user.is_staff %}
                     <li><a href="{% url 'admin:index' %}">Django admin</a></li>
+                  {% endif %}
+                  {% if perms.wwwapp.change_article %}
+                    <li><a href="{% url 'template_for_workshop_page' %}">Szablon strony warsztatów</a></li>
                   {% endif %}
                   {% if perms.wwwapp.export_workshop_registration %}
                     <li><a href="{% url 'dataForPlan' current_year.pk %}">Dane do planu</a></li>

--- a/wwwapp/tests/test_basic_views.py
+++ b/wwwapp/tests/test_basic_views.py
@@ -11,7 +11,7 @@ from wwwapp.models import Camp, WorkshopType, WorkshopCategory, Workshop, Worksh
 # This is just so that we have something basic until somebody wries better tests
 # TODO: write more proper tests for these views
 
-class CampQualificationViews(TestCase):
+class TestBasicViews(TestCase):
     def setUp(self):
         Camp.objects.all().update(year=2020, start_date=datetime.date(2020, 7, 3), end_date=datetime.date(2020, 7, 15))
         self.year_2020 = Camp.objects.get()


### PR DESCRIPTION
I'm not sure who designed it that way originally, but this seems more logical. With the new workshop status buttons and workshops being directly editable by admins, the template was getting applied as soon as the workshop was accepted. This makes it possible to edit the template between accepting the workshop and the lecturer actually filling out the page.

I also added the workshop page template editor to the header navigation bar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/259)
<!-- Reviewable:end -->
