### PR TITLE
Ignore tests directory for coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     ./venv/*
     ./gallery/*
     ./wwwapp/migrations/*
+    ./wwwapp/tests/*
     ./wwwapp/management/commands/download_remote_images.py
     ./wwwapp/settings*.py
     ./wwwapp/wsgi.py
@@ -16,7 +17,7 @@ relative_files = True
 
 [report]
 show_missing = True
-skip_covered = True
+skip_covered = False
 exclude_lines =
     pragma: no cover
     if settings.DEBUG

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Aplikacja WWW
 =============
 
+[![Python test](https://github.com/warsztatywww/aplikacjawww/workflows/Python%20test/badge.svg)](https://github.com/warsztatywww/aplikacjawww/actions?query=branch%3Amaster+workflow%3A%22Python+test%22)
+[![codecov](https://codecov.io/gh/warsztatywww/aplikacjawww/branch/master/graph/badge.svg?token=xqOEznDxRX)](https://codecov.io/gh/warsztatywww/aplikacjawww)
+
 Django-based application to manage registration of people for [scientific summer school](https://warsztatywww.pl/).
 
 ### Setup:


### PR DESCRIPTION
The tests directory will always have 100% coverage and artifically increases the coverage numbers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/261)
<!-- Reviewable:end -->
