### PR TITLE
Remove CURRENT_YEAR

### DIFF
--- a/wwwapp/settings_common.py
+++ b/wwwapp/settings_common.py
@@ -217,10 +217,6 @@ TINYMCE_DEFAULT_CONFIG_WITH_IMAGES = {  # Additional settings for editors where 
     'file_picker_callback': 'tinymce_local_file_picker',
 }
 
-CURRENT_YEAR = 2020
-WORKSHOPS_START_DATE = datetime.date(2020, 7, 3)
-WORKSHOPS_END_DATE = datetime.date(2020, 7, 15)
-
 COMPRESS_ENABLED = True
 
 INTERNAL_IPS = [


### PR DESCRIPTION
Now that we migrated the prod server we can finally get rid of this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/270)
<!-- Reviewable:end -->
