### PR TITLE
Fix broken unresponsive facebook sometimes getting fractional pixel values

### DIFF
--- a/frontend/js/warsztatywww.js
+++ b/frontend/js/warsztatywww.js
@@ -147,8 +147,8 @@ $(function () {
                 return;
             if($(this).width() == 0 || $(this).height() == 0)
                 return;
-            url = url.replace(/width=([0-9]+)/, 'width=' + $(this).width());
-            url = url.replace(/height=([0-9]+)/, 'height=' + $(this).height());
+            url = url.replace(/width=([0-9]+)/, 'width=' + Math.round($(this).width()));
+            url = url.replace(/height=([0-9]+)/, 'height=' + Math.round($(this).height()));
             if ($(this).attr('src') != url)
                 $(this).attr('src', url);
         });


### PR DESCRIPTION
I'm not sure how I managed to break it but I managed to break it semi-reproducibly when resizing the window a lot. Passing a floating-point here throws an error in the iframe and breaks the regex used for replacing the width and height

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/321)
<!-- Reviewable:end -->
