### PR TITLE
Remove has_workshops from global context

### DIFF
--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -44,12 +44,7 @@ from .templatetags.wwwtags import qualified_mark
 def get_context(request):
     context = {}
 
-    context['has_workshops'] = False
-
     if request.user.is_authenticated:
-        if Workshop.objects.filter(lecturer__user=request.user).exists():
-            context['has_workshops'] = True
-
         visible_resources = ResourceYearPermission.objects.exclude(access_url__exact="")
         if request.user.has_perm('wwwapp.access_all_resources'):
             context['resources'] = visible_resources


### PR DESCRIPTION
It's no longer necessary and saves one query on every page where you are logged in :P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/333)
<!-- Reviewable:end -->
