### PR TITLE
Make it possible to register on the workshop page

### DIFF
--- a/frontend/js/warsztatywww.js
+++ b/frontend/js/warsztatywww.js
@@ -89,6 +89,7 @@ window.handle_registration_change = function(workshop_name_txt, register) {
     } else {
         proper_url = $("#" + workshop_name_txt).data('unregister');
     }
+    var no_workshop_card_header = $("#" + workshop_name_txt).find('.card-header').length === 0;
 
     function error(message) {
         var elem = $('<div class="alert alert-danger fade"><a href="#" class="close" data-dismiss="alert">&times;</a>' +
@@ -114,6 +115,8 @@ window.handle_registration_change = function(workshop_name_txt, register) {
             }
             if (json.content) {
                 $("#" + workshop_name_txt).replaceWith(json.content);
+                if (no_workshop_card_header)
+                    $("#" + workshop_name_txt).find('.card-header').replaceWith('');
                 $("#" + workshop_name_txt).find('.enable-tooltip').tooltip();
             }
         },

--- a/templates/_programworkshop.html
+++ b/templates/_programworkshop.html
@@ -1,4 +1,5 @@
 <div class="card mb-3 w-100" id="{{ workshop.name }}" data-register="{% url 'register_to_workshop' workshop.year.pk workshop.name %}" data-unregister="{% url 'unregister_from_workshop' workshop.year.pk workshop.name %}">
+  {% if not no_workshop_card_header %}
   <div class="card-header">
     <div class="row">
       <div class="col-12 col-lg-8">
@@ -22,6 +23,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
   <div class="card-body">
     <div class="row">
       <div class="col-md-10">

--- a/templates/workshoppage.html
+++ b/templates/workshoppage.html
@@ -2,39 +2,11 @@
 {% load bleach_tags %}
 
 {% block workshop_page_content %}
+  {% include "_programworkshop.html" with no_workshop_card_header=True %}
   {% if is_lecturer %}
-    {% if workshop.is_qualifying and workshop.qualification_problems %}
-      <p>Twoje zadania kwalifikacyjne są <a target="_blank" href="{% url 'qualification_problems' workshop.year.pk workshop.name%}">tutaj</a>.</p>
-    {% elif not workshop.is_qualifying %}
-      <p>Na Twoje warsztaty nie obowiązuje kwalifikacja.</p>
-    {% else %}
+    {% if workshop.is_qualifying and not workshop.qualification_problems %}
       <div class="alert alert-danger" role="alert">Nie wstawiłeś jeszcze zadań kwalifikacyjnych!</div>
     {% endif %}
-  {% else %}
-    {% if workshop.is_qualifying and workshop.qualification_problems %}
-      <p>Zadania kwalifikacyjne są <a target="_blank" href="{% url 'qualification_problems' workshop.year.pk workshop.name%}">tutaj</a>.</p>
-    {% elif not workshop.is_qualifying %}
-      <p>Na te warsztaty nie obowiązuje kwalifikacja.</p>
-    {% else %}
-      {% if workshop.page_content_is_public %}
-        <p>Nie ma jeszcze zadań kwalifikacyjnych.</p>
-      {% elif has_perm_to_edit %}
-        <div class="alert alert-info" role="alert">Nie ma jeszcze zadań kwalifikacyjnych.</div>
-      {% endif %}
-    {% endif %}
-  {% endif %}
-
-  {% if workshop.can_access_solution_upload and workshop.are_solutions_editable %}
-    <span class="d-inline-block enable-tooltip"
-        {# this wrapper div is here to allow the tooltip to work on a disabled element, see https://getbootstrap.com/docs/4.0/components/tooltips/#disabled-elements #}
-        {% if not registered %}data-toggle="tooltip" data-placement="right" title="Przed przesłaniem rozwiązań, zapisz się na warsztaty"{% endif %}
-    >
-      <a role="button"
-         class="btn btn-primary btn-sm {% if not registered %}disabled{% endif %}"
-         href="{% url 'workshop_my_solution' workshop.year.pk workshop.name %}">
-        <i class="fas fa-paper-plane"></i> Prześlij rozwiązania!
-      </a>
-    </span>
   {% endif %}
 
   {% if workshop.page_content_is_public %}


### PR DESCRIPTION
This was implemented by placing the entire program card on the workshop page (minus the header with the title and lecturers, which is already on the page elsewhere). This means that as a bonus we also get other metadata (such as categories) and better qualification problems / solution upload buttons.

![screencapture-localhost-8000-2021-workshop-dfsdfdf-2021-03-05-12_40_30](https://user-images.githubusercontent.com/1517255/110111152-2c8baf00-7db0-11eb-9e1b-176b80aa66dc.png)

Closes #343

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/364)
<!-- Reviewable:end -->
