### PR TITLE
Add a slight margin between title and lecturer on mobile

### DIFF
--- a/templates/_programworkshop.html
+++ b/templates/_programworkshop.html
@@ -12,7 +12,7 @@
         {% if workshop.status == 'X' %}&nbsp;&nbsp;<span class="text-danger">(odwołane)</span>{% endif %}
         </h4>
       </div>
-      <div class="col-12 col-lg-4 text-right">
+      <div class="col-12 col-lg-4 text-right mt-2 mt-lg-0">
         <h5 class="m-0">
         {% for lecturer in workshop.lecturer.all %}
           <span class="d-inline-block"> {# this makes it so that line breaks are preferred at the point of the comma, not in the middle of the name #}


### PR DESCRIPTION
I think this margin used to be there before the bootstrap4 rewrite and it looked better this way

Before:
![Screenshot_20210306-194515_Chrome](https://user-images.githubusercontent.com/1517255/110217505-98574000-7eb4-11eb-88eb-7158a1cfb47f.jpg)

After:
![Screenshot_20210306-194455_Chrome](https://user-images.githubusercontent.com/1517255/110217508-9beac700-7eb4-11eb-8b94-442727f00c20.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/393)
<!-- Reviewable:end -->
