### PR TITLE
Link the deploy workflow with GitHub environments

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -57,9 +57,12 @@ jobs:
       
   deploy:
     # The type of runner that the job will run on
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master'
+    environment:
+      name: production
+      url: https://warsztatywww.pl
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Runs a single command using the runners shell

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Test than deploy
 
 on: 
@@ -56,22 +53,30 @@ jobs:
       if: matrix.python-version == 3.8
       
   deploy:
-    # The type of runner that the job will run on
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
     environment:
       name: production
       url: https://warsztatywww.pl
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Runs a single command using the runners shell
+      # Fetching the repository is required for Sentry to determine commits for this deploy
+      - uses: actions/checkout@v2
+
       - uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      # Runs a set of commands using the runners shell
       - name: Run a multi-line script
         run: |
           echo warsztatywww.pl ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNWqatTc0A9bJT+WmSHOuSpm+a83QcSScetN5KClPbOjtEum1IeA6sU+QXHbTh2TLXYPr2H+/5IoXgFIyPt4NAc= >~/.ssh/known_hosts
           ssh deploy@warsztatywww.pl "$GITHUB_SHA"
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: warsztatywww
+          SENTRY_PROJECT: aplikacjawww
+        with:
+          environment: production


### PR DESCRIPTION
This makes the current deployed version visible in the GitHub UI and unlocks options such as deployment approvals.

Before merging:
1. Go to `Settings > Environments` and create the `production` environment
2. Set up protection rules to make sure only the `master` branch can use this environment
3. Move the `SSH_PRIVATE_KEY` secret from repository-level to environment-level
4. **Maybe?**: Enable deploy approvals - this makes it so that you have to press a button on GitHub to deploy, preventing queueing up of deploys when a bunch of Dependabot PRs are merged
    * Note: From what I tested there seems to be nothing preventing you from approving the deploys in a wrong order and deploying an older version on top of a newer one if multiple ones are pending. You also can't re-deploy the newer one if it was already deployed once...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/411)
<!-- Reviewable:end -->
