### PR TITLE
Hide the register and solutions buttons on mobile program page

### DIFF
--- a/frontend/js/warsztatywww.js
+++ b/frontend/js/warsztatywww.js
@@ -124,8 +124,12 @@ window.handle_registration_change = function(workshop_name_txt, register) {
             }
             if (json.content) {
                 $("#" + workshop_name_txt).replaceWith(json.content);
-                if (no_workshop_card_header)
+                if (no_workshop_card_header) {
                     $("#" + workshop_name_txt).find('.card-header').replaceWith('');
+                    $("#" + workshop_name_txt).find('.button-div').removeClass('d-none d-md-block');
+                    $("#" + workshop_name_txt).find('.solutions-button').removeClass('d-none d-md-inline-block');
+                    $("#" + workshop_name_txt).find('.solutions-button').addClass('d-inline-block');
+                }
                 $("#" + workshop_name_txt).find('[data-toggle="tooltip"]').tooltip();
             }
         },

--- a/templates/_programworkshop.html
+++ b/templates/_programworkshop.html
@@ -40,7 +40,7 @@
           <div class="col-6 col-lg-4">Zadania kwalifikacyjne:</div>
           <div class="col-6 col-lg-8">
             {% if workshop.is_qualifying %}
-              <span class="d-inline-block w-100-on-sm mb-1 mb-md-0"
+              <span class="d-inline-block w-100-on-sm mb-1 mb-md-0 qualification-problems-button"
                 {# this wrapper div is here to allow the tooltip to work on a disabled element, see https://getbootstrap.com/docs/4.0/components/tooltips/#disabled-elements #}
                 {% if not workshop.qualification_problems %}data-toggle="tooltip" data-placement="right" title="Zadania kwalifikacyjne pojawią się wkrótce"{% endif %}
               >
@@ -52,7 +52,7 @@
               </span>
 
               {% if workshop.can_access_solution_upload and workshop.are_solutions_editable %}
-                <span class="d-inline-block w-100-on-sm mb-1 mb-md-0"
+                <span class="{% if not no_workshop_card_header %}d-none d-md-inline-block{% else %}d-inline-block{% endif %} w-100-on-sm mb-1 mb-md-0 solutions-button"
                     {# this wrapper div is here to allow the tooltip to work on a disabled element, see https://getbootstrap.com/docs/4.0/components/tooltips/#disabled-elements #}
                     {% if not registered %}data-toggle="tooltip" data-placement="right" title="Przed przesłaniem rozwiązań, zapisz się na warsztaty"{% endif %}
                 >
@@ -78,7 +78,7 @@
           </div>
         </div>
       </div>
-      <div class="col-md-2 text-center button-div">
+      <div class="col-md-2 text-center button-div {% if not no_workshop_card_header %}d-none d-md-block{% endif %}">
         {% if workshop.is_qualification_editable %}
           {% if registered %}
             <div onclick="handle_registration_change('{{ workshop.name }}', false);" style="cursor: pointer;">


### PR DESCRIPTION
They are still displayed on the full workshop page, but space in the program listing on mobile is precious.

This solution is ugly but whatever, I just want something that works for this year for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/454)
<!-- Reviewable:end -->
