### PR TITLE
Fix bleach version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Django==3.2.12
 django-crispy-forms==1.13.0
 django-tinymce==3.4.0
 django-bleach==1.0.0
+bleach>=1.5.0,<5.0.0
 django-cleanup==5.2.0
 django-sendfile2==0.6.1
 django-debug-toolbar==3.2.4


### PR DESCRIPTION
django-bleach does not pin the version of bleach, so a version
with breaking changes got pulled in.

For now, just ensure we are using the older version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/594)
<!-- Reviewable:end -->
