### PR TITLE
Fix people table when "interests" are displayed

### DIFF
--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -692,7 +692,7 @@ def _people_datatable(request: HttpRequest, year: Optional[Camp], participants: 
             'points': 0.0,
             'infos': [],
             'how_do_you_know_about': '',
-            'form_answers': [],
+            'form_answers': zip(all_questions, [None for _ in all_questions]),
         }
         people.append(person)
 


### PR DESCRIPTION
emails of "interested" people broke the table previously

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/662)
<!-- Reviewable:end -->
