### PR TITLE
Label phone numbers in vcard

### DIFF
--- a/frontend/js/datatables_vcard_export.ts
+++ b/frontend/js/datatables_vcard_export.ts
@@ -25,7 +25,7 @@ export function vcard_export(e, dt, button, config) {
     const emergencyDescriptionColumn = dt.columns().indexes().map(function (idx) {
         const column = dt.column(idx);
         const columnName = column.header().innerText;
-        return columnName === "Do kogo jest powyższy numer?" ? idx : -1;
+        return columnName.includes  ("Do kogo jest powyższy numer?") ? idx : -1;
     }).toArray().filter(index => index !== -1)[0];
 
     const data = dt.buttons.exportData().body;
@@ -52,8 +52,8 @@ export function vcard_export(e, dt, button, config) {
                 let phoneLabel = "Numer uczestnika"; // Default label for participant's phone
                 
                 // If it's an emergency phone, get its description if available
-                if (columnName.includes("awaryjn") && emergencyDescriptionColumn !== -1 && row[emergencyDescriptionColumn] 
-                    && row[emergencyDescriptionColumn].includes("powyższy numer")) {
+                if (columnName.includes("awaryjn") && emergencyDescriptionColumn !== -1 && row[emergencyDescriptionColumn]) {
+                    // Use the description from the emergency contact description column
                     phoneLabel = `Numer awaryjny(${row[emergencyDescriptionColumn]})`;
                 } else if (columnName.includes("awaryjn")) {
                     phoneLabel = "Numer awaryjny";

--- a/frontend/js/datatables_vcard_export.ts
+++ b/frontend/js/datatables_vcard_export.ts
@@ -49,14 +49,14 @@ export function vcard_export(e, dt, button, config) {
                 const columnName = dt.column(columnIdx).header().innerText;
                 
                 // Determine the appropriate label based on column name or index
-                let phoneLabel = "Numer uczestnika"; // Default label for participant's phone
+                let phoneLabel = "WWW własny"; // Default label for participant's phone
                 
                 // If it's an emergency phone, get its description if available
                 if (columnName.includes("awaryjn") && emergencyDescriptionColumn !== -1 && row[emergencyDescriptionColumn]) {
                     // Use the description from the emergency contact description column
-                    phoneLabel = `Numer awaryjny(${row[emergencyDescriptionColumn]})`;
+                    phoneLabel = `WWW awaryjny(${row[emergencyDescriptionColumn]})`;
                 } else if (columnName.includes("awaryjn")) {
-                    phoneLabel = "Numer awaryjny";
+                    phoneLabel = "WWW awaryjny";
                 }
                 
                 // Use the hack to add the labeled phone number

--- a/wwwapp/management/commands/populate_with_test_data.py
+++ b/wwwapp/management/commands/populate_with_test_data.py
@@ -76,6 +76,25 @@ class Command(BaseCommand):
                                                 value_string=profile_data['ssn'])
                 self.question_address.answers.create(user=user,
                                                   value_string=profile_data['address'])
+                
+                # Add participant's phone number
+                phone_number = "+48" + self.fake.numerify(text="#########") # Polish number format
+                self.question_phone.answers.create(user=user,
+                                               value_string=phone_number)
+                
+                # Add emergency phone number only for some participants (75% of them)
+                if random.random() < 0.75:
+                    emergency_phone = "+48" + self.fake.numerify(text="#########")
+                    self.question_emergency_phone.answers.create(user=user,
+                                                   value_string=emergency_phone)
+                    
+                    # Add description for some emergency phone numbers
+                    if random.random() < 0.75:
+                        emergency_contacts = ["Mama", "Tata", "Rodzice", "Opiekun", "Babcia", "Dziadek", "Siostra", "Brat"]
+                        emergency_desc = self.fake.random_element(emergency_contacts)
+                        self.question_emergency_phone_desc.answers.create(user=user,
+                                                        value_string=emergency_desc)
+                    
                 self.question_comments.answers.create(user=user,
                                                    value_string=self.fake.text(100))
                 
@@ -195,17 +214,23 @@ class Command(BaseCommand):
             title='Adres zameldowania', data_type=FormQuestion.TYPE_TEXTBOX,
             is_required=True, order=1)
         self.question_phone, _ = self.form_userinfo.questions.get_or_create(
-            title='Numer telefonu', data_type=FormQuestion.TYPE_STRING,
+            title='Numer telefonu do Ciebie', data_type=FormQuestion.TYPE_PHONE,
             is_required=True, order=2)
+        self.question_emergency_phone, _ = self.form_userinfo.questions.get_or_create(
+            title='Numer telefonu w sytuacjach awaryjnych (np. do rodziców)', data_type=FormQuestion.TYPE_PHONE,
+            is_required=True, order=3)
+        self.question_emergency_phone_desc, _ = self.form_userinfo.questions.get_or_create(
+            title='Do kogo jest powyższy numer?', data_type=FormQuestion.TYPE_STRING,
+            is_required=True, order=4)
         self.question_start_date, _ = self.form_userinfo.questions.get_or_create(
             title='Data przyjazdu :-)', data_type=FormQuestion.TYPE_DATE,
-            is_required=True, order=3)
+            is_required=True, order=5)
         self.question_end_date, _ = self.form_userinfo.questions.get_or_create(
             title='Data wyjazdu :-(', data_type=FormQuestion.TYPE_DATE,
-            is_required=True, order=4)
+            is_required=True, order=6)
         self.question_tshirt_size, _ = self.form_userinfo.questions.get_or_create(
             title='Rozmiar koszulki', data_type=FormQuestion.TYPE_SELECT,
-            is_required=False, order=5)
+            is_required=False, order=7)
         self.tshirt_sizes = {}
         for size in ['XS', 'S', 'M', 'L', 'XL', 'XXL']:
             self.tshirt_sizes[
@@ -213,7 +238,7 @@ class Command(BaseCommand):
                 title=size)
         self.question_comments, _ = self.form_userinfo.questions.get_or_create(
             title='Dodatkowe uwagi (np. wegetarianin, uczulony na X, ale też inne)',
-            data_type=FormQuestion.TYPE_TEXTBOX, is_required=False, order=6)
+            data_type=FormQuestion.TYPE_TEXTBOX, is_required=False, order=8)
         self.form_userinfo.save()
 
     def do_ignore_integrity_error(self, task: Callable[[], None]) -> None:


### PR DESCRIPTION
Fixes #672 

Now after importing to google contacts if the user provided an emergency number:
![image](https://github.com/user-attachments/assets/350d2290-fd36-4bf8-a641-f0cf169db644)
In case the user doesn't specify what's the emergency number for:
![image](https://github.com/user-attachments/assets/7f551f33-ebf3-4d18-bca7-645d034bef54)

The labeling of numbers can break in the future as there is no formal number - label relation in the database - such relation would need to be added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/673)
<!-- Reviewable:end -->
