### PR TITLE
Fix invoice attachment validation errors

### DIFF
--- a/wwwapp/forms.py
+++ b/wwwapp/forms.py
@@ -603,7 +603,7 @@ class InvoiceForm(ModelForm):
             'description': 'Opis',
         }
         help_texts = {
-            'attachment': 'Załącz skan lub plik PDF dokumentu (PDF, JPG lub JPEG; maks. 50 MiB).',
+            'attachment': 'Załącz skan lub plik PDF dokumentu (PDF, JPG, JPEG lub PNG; maks. 50 MiB).',
             'document_number': 'Przepisz numer widoczny na fakturze lub rachunku.',
             'issue_date': 'Wybierz datę wystawienia widoczną na dokumencie.',
             'amount': 'Łączna kwota brutto dokumentu. Musi być równa sumie pozycji kosztowych.',
@@ -626,7 +626,7 @@ class InvoiceForm(ModelForm):
             return attachment
 
         if not self._looks_like_supported_document(attachment):
-            raise ValidationError('Załącznik musi być plikiem PDF, JPG lub JPEG.')
+            raise ValidationError('Załącznik musi być plikiem PDF, JPG, JPEG lub PNG.')
         if attachment.size > self.MAX_ATTACHMENT_SIZE:
             raise ValidationError('Załącznik nie może być większy niż 50 MiB.')
         return attachment
@@ -639,7 +639,11 @@ class InvoiceForm(ModelForm):
             attachment.seek(0)
         except (OSError, ValueError):
             return False
-        return header.startswith(b'%PDF-') or header[:3] == b'\xff\xd8\xff'
+        return (
+            header.startswith(b'%PDF-')
+            or header[:3] == b'\xff\xd8\xff'
+            or header == b'\x89PNG\r\n\x1a\n'
+        )
 
 
 class CostItemForm(ModelForm):

--- a/wwwapp/forms.py
+++ b/wwwapp/forms.py
@@ -682,7 +682,7 @@ class BaseCostItemInlineFormSet(BaseInlineFormSet):
 
     def clean(self):
         super().clean()
-        if any(self.errors):
+        if any(self.errors) or self.invoice_amount is None:
             return
 
         items = [

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -103,10 +103,11 @@ class InvoiceFormTests(TestCase):
         self.assertFalse(form.is_valid())
         self.assertIn('attachment', form.errors)
 
-    def test_attachment_accepts_pdf_and_jpeg_signatures(self):
+    def test_attachment_accepts_pdf_jpeg_and_png_signatures(self):
         for name, content, content_type in (
             ('invoice.pdf', b'%PDF-1.7', 'application/pdf'),
             ('invoice.jpeg', b'\xff\xd8\xff\xe0', 'image/jpeg'),
+            ('invoice.png', b'\x89PNG\r\n\x1a\n', 'image/png'),
         ):
             with self.subTest(name=name):
                 form = InvoiceForm(
@@ -551,13 +552,13 @@ class OwnCostsViewsTests(TestCase):
             {
                 **self.invoice_post_data(),
                 'attachment': SimpleUploadedFile(
-                    'invoice.png', b'\x89PNG\r\n\x1a\n', content_type='image/png',
+                    'invoice.gif', b'GIF89a', content_type='image/gif',
                 ),
             },
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'Załącznik musi być plikiem PDF, JPG lub JPEG.')
+        self.assertContains(response, 'Załącznik musi być plikiem PDF, JPG, JPEG lub PNG.')
         self.assertNotContains(
             response,
             'Suma pozycji kosztowych musi być równa kwocie faktury.',

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -538,6 +538,31 @@ class OwnCostsViewsTests(TestCase):
 
         self.assertContains(response, 'Suma pozycji kosztowych musi być równa kwocie faktury.')
 
+    def test_invoice_add_displays_attachment_error_without_allocation_error(self):
+        SettlementDetails.objects.create(
+            user=self.user,
+            camp=self.camp,
+            account_number='PL61109010140000071219812874',
+        )
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse('costs_invoice_add', args=[self.camp.pk]),
+            {
+                **self.invoice_post_data(),
+                'attachment': SimpleUploadedFile(
+                    'invoice.png', b'\x89PNG\r\n\x1a\n', content_type='image/png',
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Załącznik musi być plikiem PDF, JPG lub JPEG.')
+        self.assertNotContains(
+            response,
+            'Suma pozycji kosztowych musi być równa kwocie faktury.',
+        )
+
     def test_invoice_edit_displays_allocation_error_and_remaining_amount_action(self):
         cost_item = CostItem.objects.create(
             invoice=self.invoice,


### PR DESCRIPTION
## What changed

- Allow verified PNG invoice attachments alongside PDF and JPEG files.
- Show PNG in attachment help and validation messages.
- Skip allocation-total validation when the invoice form has no valid amount.
- Cover PNG acceptance and rejected unsupported attachments.

## Root cause

PNG files were rejected because the attachment validator recognized only PDF and JPEG signatures. An invalid attachment also caused an unrelated allocation-total error.

## Validation

- manage.py test wwwapp.tests.test_costs_views -v 2: 66 tests passed.
- manage.py makemigrations --check --dry-run: no changes detected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/703)
<!-- Reviewable:end -->
