### PR TITLE
Improve cost statistics

### DIFF
--- a/templates/costs_statistics.html
+++ b/templates/costs_statistics.html
@@ -8,7 +8,32 @@
       {% crispy filter_form %}
     </form>
 
-    <p>Łącznie: {{ total|floatformat:2 }} zł</p>
+    <section class="card mb-4" aria-labelledby="cost-summary-heading">
+      <div class="card-body">
+        <h2 class="h4" id="cost-summary-heading">Podsumowanie kosztów</h2>
+        <div class="row">
+          <div class="col-md-4 mb-3 mb-md-0">
+            <div class="border rounded h-100 p-3">
+              <div class="small text-muted">Wszystkie koszty</div>
+              <div class="h4 mb-0">{{ total|floatformat:2 }} zł</div>
+            </div>
+          </div>
+          <div class="col-md-4 mb-3 mb-md-0">
+            <div class="border rounded h-100 p-3">
+              <div class="small text-muted">Paragony nieksięgowe</div>
+              <div class="h4 mb-0">{{ non_accounting_total|floatformat:2 }} zł</div>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="border rounded h-100 p-3">
+              <div class="small text-muted">Pozostałe koszty</div>
+              <div class="h4 mb-0">{{ accounting_total|floatformat:2 }} zł</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <h2>Wydatki według kategorii</h2>
     <div class="row align-items-center">
       <div class="col-md-auto">
@@ -54,5 +79,26 @@
         </table>
       </div>
     </div>
+
+    <h2>Wydatki według warsztatu</h2>
+    {% if workshop_rows %}
+      <div class="table-responsive">
+        <table class="table mt-3">
+          <thead>
+            <tr><th scope="col">Warsztat</th><th scope="col">Kwota</th></tr>
+          </thead>
+          <tbody>
+            {% for row in workshop_rows %}
+              <tr>
+                <td>{{ row.workshop__title }}</td>
+                <td>{{ row.total|floatformat:2 }} zł</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p class="text-muted">Brak kosztów przypisanych do warsztatów.</p>
+    {% endif %}
   </article>
 {% endblock %}

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -1205,6 +1205,68 @@ class ReimbursementAndStatisticsViewsTests(TestCase):
             Decimal('0.00'),
         )
 
+    def test_statistics_filter_applies_to_summary_and_workshop_costs(self):
+        workshop_type = WorkshopType.objects.create(year=self.camp, name='Statistics type')
+        expensive_workshop = Workshop.objects.create(
+            year=self.camp,
+            type=workshop_type,
+            name='expensive-workshop',
+            title='Expensive workshop',
+        )
+        inexpensive_workshop = Workshop.objects.create(
+            year=self.camp,
+            type=workshop_type,
+            name='inexpensive-workshop',
+            title='Inexpensive workshop',
+        )
+        Workshop.objects.create(
+            year=self.camp,
+            type=workshop_type,
+            name='workshop-without-costs',
+            title='Workshop without costs',
+        )
+        non_accounting_invoice = self.create_invoice(
+            amount=Decimal('40.00'),
+            status=Invoice.Status.RECEIVED,
+        )
+        non_accounting_invoice.invoice_type = Invoice.Type.NON_ACCOUNTING_RECEIPT
+        non_accounting_invoice.save(update_fields=['invoice_type'])
+        non_accounting_invoice.cost_items.update(workshop=expensive_workshop)
+        accounting_invoice = self.create_invoice(
+            amount=Decimal('15.00'),
+            status=Invoice.Status.RECEIVED,
+        )
+        accounting_invoice.cost_items.update(workshop=inexpensive_workshop)
+        self.client.force_login(self.statistics_user)
+
+        response = self.client.get(
+            reverse('costs_statistics', args=[self.camp.pk]),
+            {'status': Invoice.Status.RECEIVED},
+        )
+
+        self.assertEqual(response.context['total'], Decimal('55.00'))
+        self.assertEqual(response.context.get('non_accounting_total'), Decimal('40.00'))
+        self.assertEqual(response.context.get('accounting_total'), Decimal('15.00'))
+        self.assertEqual(
+            response.context.get('workshop_rows'),
+            [
+                {
+                    'workshop_id': expensive_workshop.pk,
+                    'workshop__title': expensive_workshop.title,
+                    'total': Decimal('40.00'),
+                },
+                {
+                    'workshop_id': inexpensive_workshop.pk,
+                    'workshop__title': inexpensive_workshop.title,
+                    'total': Decimal('15.00'),
+                },
+            ],
+        )
+        self.assertContains(response, 'Podsumowanie kosztów')
+        self.assertContains(response, 'Paragony nieksięgowe')
+        self.assertContains(response, 'Pozostałe koszty')
+        self.assertNotContains(response, 'Workshop without costs')
+
     def test_statistics_ignores_removed_context_filter(self):
         workshop_type = WorkshopType.objects.create(year=self.camp, name='Statistics type')
         workshop = Workshop.objects.create(

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -471,6 +471,17 @@ def costs_statistics_view(request, year):
         }
         for value, label in CostItem.Category.choices
     ]
+    non_accounting_total = items.filter(
+        invoice__invoice_type=Invoice.Type.NON_ACCOUNTING_RECEIPT,
+    ).aggregate(total=Sum('amount'))['total'] or Decimal('0.00')
+    accounting_total = total - non_accounting_total
+    workshop_rows = list(
+        items.filter(workshop__isnull=False)
+        .values('workshop_id', 'workshop__title')
+        .annotate(total=Sum('amount'))
+        .exclude(total=Decimal('0.00'))
+        .order_by('-total', 'workshop__title', 'workshop_id')
+    )
     colors = ('#0072b2', '#e69f00', '#009e73', '#cc79a7', '#d55e00', '#56b4e9')
     start_angle = -90
     for row, color in zip(category_rows, colors):
@@ -486,6 +497,9 @@ def costs_statistics_view(request, year):
         'category_percentages': category_percentages,
         'category_rows': category_rows,
         'total': total,
+        'non_accounting_total': non_accounting_total,
+        'accounting_total': accounting_total,
+        'workshop_rows': workshop_rows,
         'has_statistics_data': bool(total),
     }
     return render(request, 'costs_statistics.html', context)


### PR DESCRIPTION
## Summary

- add status-filtered cost summary totals for all costs, non-accounting receipts, and other costs
- list workshop costs from highest to lowest, omitting zero totals
- cover the new filter behavior with a focused view test

## Validation

- `/home/ubuntu/aplikacjawww/.venv/bin/python manage.py test wwwapp.tests.test_costs_views -v 1`
- `/home/ubuntu/aplikacjawww/.venv/bin/python manage.py makemigrations --check --dry-run`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/704)
<!-- Reviewable:end -->
