### PR TITLE
Separate invoice numbering series

### DIFF
--- a/wwwapp/admin.py
+++ b/wwwapp/admin.py
@@ -4,11 +4,13 @@ from adminsortable2.admin import SortableAdminMixin
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.db.models.base import Model
 from django.forms.models import BaseInlineFormSet
 from django.http.request import HttpRequest
 
 import wwwforms.models
+from wwwapp.costs import allocate_invoice_number
 from .models import Article, UserProfile, ArticleContentHistory, \
     WorkshopCategory, Workshop, WorkshopType, WorkshopParticipant, \
     CampParticipant, ResourceYearPermission, Camp, Solution, SolutionFile, CampInterestEmail, \
@@ -240,6 +242,20 @@ class InvoiceAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj and obj.internal_number:
+            return ('camp', 'invoice_type')
+        return ()
+
+    @transaction.atomic
+    def save_model(self, request, obj, form, change):
+        if obj.status == Invoice.Status.APPROVED and not obj.internal_number:
+            obj.internal_number = allocate_invoice_number(
+                camp=obj.camp,
+                invoice_type=obj.invoice_type,
+            )
+        super().save_model(request, obj, form, change)
 
 
 @admin.register(CostItem)

--- a/wwwapp/costs.py
+++ b/wwwapp/costs.py
@@ -27,18 +27,23 @@ CSV_FIELDS = (
 
 
 @transaction.atomic
-def allocate_invoice_number(*, camp):
+def allocate_invoice_number(*, camp, invoice_type):
     """Allocate the next internal invoice number for a workshop edition."""
+    series = (
+        InvoiceSequence.Series.FPZ
+        if invoice_type == Invoice.Type.NON_ACCOUNTING_RECEIPT
+        else InvoiceSequence.Series.FP
+    )
     try:
         with transaction.atomic():
-            sequence, created = InvoiceSequence.objects.get_or_create(camp=camp)
+            sequence, created = InvoiceSequence.objects.get_or_create(camp=camp, series=series)
     except IntegrityError:
         created = False
     if not created:
-        sequence = InvoiceSequence.objects.select_for_update().get(camp=camp)
+        sequence = InvoiceSequence.objects.select_for_update().get(camp=camp, series=series)
     sequence.last_allocated += 1
     sequence.save(update_fields=['last_allocated'])
-    return f'WWW_{camp.year}_FP_{sequence.last_allocated:04d}'
+    return f'WWW_{camp.year}_{series}_{sequence.last_allocated:04d}'
 
 
 @transaction.atomic

--- a/wwwapp/costs.py
+++ b/wwwapp/costs.py
@@ -49,10 +49,17 @@ def allocate_invoice_number(*, camp, invoice_type):
 @transaction.atomic
 def transition_invoices(*, invoices, target_status, changed_by):
     """Move all selected invoices to one valid next status, or none of them."""
-    invoices = list(invoices.select_related('user', 'camp').prefetch_related('cost_items'))
+    invoices = list(
+        invoices.select_related('user', 'camp').prefetch_related('cost_items')
+    )
     if any(not _can_transition(invoice.status, target_status) for invoice in invoices):
         raise ValidationError('Co najmniej jedna faktura nie może przejść do wybranego stanu.')
     for invoice in invoices:
+        if target_status == Invoice.Status.APPROVED and not invoice.internal_number:
+            invoice.internal_number = allocate_invoice_number(
+                camp=invoice.camp,
+                invoice_type=invoice.invoice_type,
+            )
         invoice.status = target_status
         invoice.admin_modified_by = changed_by
         invoice.admin_modified_at = timezone.now()
@@ -123,7 +130,7 @@ def _escape_csv_formula(value):
 def _can_transition(current_status, target_status):
     transitions = {
         Invoice.Status.RECEIVED: (Invoice.Status.APPROVED, Invoice.Status.REJECTED),
-        Invoice.Status.APPROVED: (Invoice.Status.PROCESSED, Invoice.Status.REJECTED),
+        Invoice.Status.APPROVED: (Invoice.Status.PROCESSED,),
         Invoice.Status.REJECTED: (Invoice.Status.APPROVED,),
     }
     return target_status in transitions.get(current_status, ())

--- a/wwwapp/forms.py
+++ b/wwwapp/forms.py
@@ -616,6 +616,8 @@ class InvoiceForm(ModelForm):
         super().__init__(*args, **kwargs)
         self.instance.user = user
         self.instance.camp = camp
+        if self.instance.internal_number:
+            self.fields['invoice_type'].disabled = True
         self.helper = FormHelper(self)
         self.helper.form_tag = False
         self.helper.include_media = False

--- a/wwwapp/management/commands/populate_with_test_data.py
+++ b/wwwapp/management/commands/populate_with_test_data.py
@@ -614,6 +614,7 @@ class Command(BaseCommand):
                 f"Completed camp for year {year_number} with {len(workshops)} workshops")
 
         current_camp = Camp.objects.get(year=current_year)
+        last_allocated = 0
         for sequence, (user, status) in enumerate(
             zip(users, Invoice.Status.values),
             start=1,
@@ -624,6 +625,10 @@ class Command(BaseCommand):
                 account_number='PL61109010140000071219812874',
             )
             amount = Decimal(f'{sequence * 10}.00')
+            internal_number = None
+            if status in (Invoice.Status.APPROVED, Invoice.Status.PROCESSED):
+                last_allocated += 1
+                internal_number = f'WWW_{current_year}_FP_{last_allocated:04d}'
             invoice = Invoice.objects.create(
                 user=user,
                 camp=current_camp,
@@ -634,7 +639,7 @@ class Command(BaseCommand):
                 invoice_type=Invoice.Type.KSEF,
                 description='Testowy koszt do sprawdzenia widoków rozliczeń.',
                 status=status,
-                internal_number=f'WWW_{current_year}_FP_{sequence:04d}',
+                internal_number=internal_number,
             )
             CostItem.objects.create(
                 invoice=invoice,
@@ -643,7 +648,7 @@ class Command(BaseCommand):
             )
         InvoiceSequence.objects.create(
             camp=current_camp,
-            last_allocated=len(Invoice.Status.values),
+            last_allocated=last_allocated,
         )
 
         self.debug_print(

--- a/wwwapp/migrations/0092_separate_invoice_numbering_series.py
+++ b/wwwapp/migrations/0092_separate_invoice_numbering_series.py
@@ -5,6 +5,7 @@ import django.db.models.deletion
 FP = 'FP'
 FPZ = 'FPZ'
 NON_ACCOUNTING_RECEIPT = 'NON_ACCOUNTING_RECEIPT'
+NUMBERED_STATUSES = ('APPROVED', 'PROCESSED')
 
 
 def renumber_invoices(apps, schema_editor):
@@ -18,6 +19,10 @@ def renumber_invoices(apps, schema_editor):
     _replace_numbers_with_temporary_values(invoices, database)
     allocated = {}
     for invoice in invoices:
+        if invoice.status not in NUMBERED_STATUSES:
+            invoice.internal_number = None
+            invoice.save(using=database, update_fields=['internal_number'])
+            continue
         series = FPZ if invoice.invoice_type == NON_ACCOUNTING_RECEIPT else FP
         key = (invoice.camp_id, series)
         allocated[key] = allocated.get(key, 0) + 1
@@ -107,6 +112,17 @@ class Migration(migrations.Migration):
             constraint=models.UniqueConstraint(
                 fields=('camp', 'series'),
                 name='unique_invoice_sequence_series_per_camp',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='invoice',
+            name='internal_number',
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                max_length=30,
+                null=True,
+                unique=True,
             ),
         ),
         migrations.RunPython(renumber_invoices, restore_single_invoice_series),

--- a/wwwapp/migrations/0092_separate_invoice_numbering_series.py
+++ b/wwwapp/migrations/0092_separate_invoice_numbering_series.py
@@ -1,0 +1,113 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+FP = 'FP'
+FPZ = 'FPZ'
+NON_ACCOUNTING_RECEIPT = 'NON_ACCOUNTING_RECEIPT'
+
+
+def renumber_invoices(apps, schema_editor):
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+    database = schema_editor.connection.alias
+    invoices = list(
+        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
+    )
+
+    _replace_numbers_with_temporary_values(invoices, database)
+    allocated = {}
+    for invoice in invoices:
+        series = FPZ if invoice.invoice_type == NON_ACCOUNTING_RECEIPT else FP
+        key = (invoice.camp_id, series)
+        allocated[key] = allocated.get(key, 0) + 1
+        invoice.internal_number = (
+            f'WWW_{invoice.camp_id}_{series}_{allocated[key]:04d}'
+        )
+        invoice.save(using=database, update_fields=['internal_number'])
+
+    camp_ids = set(invoice.camp_id for invoice in invoices)
+    camp_ids.update(
+        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
+    )
+    for camp_id in camp_ids:
+        for series in (FP, FPZ):
+            InvoiceSequence.objects.using(database).update_or_create(
+                camp_id=camp_id,
+                series=series,
+                defaults={'last_allocated': allocated.get((camp_id, series), 0)},
+            )
+
+
+def restore_single_invoice_series(apps, schema_editor):
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+    database = schema_editor.connection.alias
+    invoices = list(
+        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
+    )
+
+    _replace_numbers_with_temporary_values(invoices, database)
+    allocated = {}
+    for invoice in invoices:
+        allocated[invoice.camp_id] = allocated.get(invoice.camp_id, 0) + 1
+        invoice.internal_number = (
+            f'WWW_{invoice.camp_id}_{FP}_{allocated[invoice.camp_id]:04d}'
+        )
+        invoice.save(using=database, update_fields=['internal_number'])
+
+    camp_ids = set(invoice.camp_id for invoice in invoices)
+    camp_ids.update(
+        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
+    )
+    InvoiceSequence.objects.using(database).filter(series=FPZ).delete()
+    for camp_id in camp_ids:
+        InvoiceSequence.objects.using(database).update_or_create(
+            camp_id=camp_id,
+            series=FP,
+            defaults={'last_allocated': allocated.get(camp_id, 0)},
+        )
+
+
+def _replace_numbers_with_temporary_values(invoices, database):
+    for invoice in invoices:
+        invoice.internal_number = f'__invoice_renumber_{invoice.pk}'
+        invoice.save(using=database, update_fields=['internal_number'])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            'wwwapp',
+            '0091_costitem_invoice_invoicesequence_reimbursement_settlementdetails',
+        ),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='invoicesequence',
+            name='series',
+            field=models.CharField(
+                choices=[('FP', 'FP'), ('FPZ', 'FPZ')],
+                default='FP',
+                max_length=3,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='invoicesequence',
+            name='camp',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                related_name='invoice_sequences',
+                to='wwwapp.camp',
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='invoicesequence',
+            constraint=models.UniqueConstraint(
+                fields=('camp', 'series'),
+                name='unique_invoice_sequence_series_per_camp',
+            ),
+        ),
+        migrations.RunPython(renumber_invoices, restore_single_invoice_series),
+    ]

--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -582,12 +582,25 @@ class Workshop(models.Model):
 
 
 class InvoiceSequence(models.Model):
-    camp = models.OneToOneField(
+    class Series(models.TextChoices):
+        FP = 'FP', 'FP'
+        FPZ = 'FPZ', 'FPZ'
+
+    camp = models.ForeignKey(
         Camp,
         on_delete=models.PROTECT,
-        related_name='invoice_sequence',
+        related_name='invoice_sequences',
     )
+    series = models.CharField(max_length=3, choices=Series.choices, default=Series.FP)
     last_allocated = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        constraints = (
+            models.UniqueConstraint(
+                fields=('camp', 'series'),
+                name='unique_invoice_sequence_series_per_camp',
+            ),
+        )
 
 
 class Invoice(models.Model):

--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -629,7 +629,13 @@ class Invoice(models.Model):
     invoice_type = models.CharField(max_length=24, choices=Type.choices)
     description = models.TextField()
     status = models.CharField(max_length=12, choices=Status.choices, default=Status.RECEIVED)
-    internal_number = models.CharField(max_length=30, unique=True, editable=False)
+    internal_number = models.CharField(
+        max_length=30,
+        unique=True,
+        editable=False,
+        null=True,
+        blank=True,
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     admin_modified_at = models.DateTimeField(null=True, blank=True)

--- a/wwwapp/tests/test_costs_models.py
+++ b/wwwapp/tests/test_costs_models.py
@@ -156,10 +156,16 @@ class CostModelTests(TestCase):
         InvoiceSequence.objects.create(camp=self.other_camp, last_allocated=41)
         empty_camp = Camp.objects.create(year=2028)
 
-        first_number = allocate_invoice_number(camp=self.camp)
-        second_number = allocate_invoice_number(camp=self.camp)
-        other_number = allocate_invoice_number(camp=self.other_camp)
-        empty_camp_number = allocate_invoice_number(camp=empty_camp)
+        first_number = allocate_invoice_number(camp=self.camp, invoice_type=Invoice.Type.KSEF)
+        second_number = allocate_invoice_number(camp=self.camp, invoice_type=Invoice.Type.KSEF)
+        other_number = allocate_invoice_number(
+            camp=self.other_camp,
+            invoice_type=Invoice.Type.KSEF,
+        )
+        empty_camp_number = allocate_invoice_number(
+            camp=empty_camp,
+            invoice_type=Invoice.Type.KSEF,
+        )
 
         self.assertEqual(first_number, 'WWW_2026_FP_0002')
         self.assertEqual(second_number, 'WWW_2026_FP_0003')
@@ -167,6 +173,26 @@ class CostModelTests(TestCase):
         self.assertEqual(empty_camp_number, 'WWW_2028_FP_0001')
         self.assertEqual(InvoiceSequence.objects.get(camp=self.camp).last_allocated, 3)
         self.assertEqual(InvoiceSequence.objects.get(camp=other_invoice.camp).last_allocated, 42)
+
+    def test_invoice_types_use_separate_numbering_series(self):
+        non_accounting_number = allocate_invoice_number(
+            camp=self.camp,
+            invoice_type=Invoice.Type.NON_ACCOUNTING_RECEIPT,
+        )
+        receipt_with_nip_number = allocate_invoice_number(
+            camp=self.camp,
+            invoice_type=Invoice.Type.RECEIPT_WITH_NIP,
+        )
+
+        self.assertEqual(non_accounting_number, 'WWW_2026_FPZ_0001')
+        self.assertEqual(receipt_with_nip_number, 'WWW_2026_FP_0002')
+        self.assertEqual(
+            set(InvoiceSequence.objects.filter(camp=self.camp).values_list(
+                'series',
+                'last_allocated',
+            )),
+            {('FP', 2), ('FPZ', 1)},
+        )
 
     def test_allocate_invoice_number_recovers_from_a_concurrent_sequence_creation(self):
         camp = Camp.objects.create(year=2028)
@@ -177,7 +203,7 @@ class CostModelTests(TestCase):
             'get_or_create',
             side_effect=lambda **kwargs: InvoiceSequence.objects.create(camp=kwargs['camp']),
         ):
-            allocated = allocate_invoice_number(camp=camp)
+            allocated = allocate_invoice_number(camp=camp, invoice_type=Invoice.Type.KSEF)
 
         self.assertEqual(allocated, 'WWW_2028_FP_0002')
         self.assertEqual(InvoiceSequence.objects.get(camp=camp).last_allocated, 2)

--- a/wwwapp/tests/test_costs_models.py
+++ b/wwwapp/tests/test_costs_models.py
@@ -97,6 +97,48 @@ class CostModelTests(TestCase):
 
         self.assertFalse(InvoiceAdmin(Invoice, site).has_add_permission(request))
 
+    def test_admin_approval_allocates_an_invoice_number(self):
+        invoice = Invoice.objects.create(
+            user=self.user,
+            camp=self.other_camp,
+            document_number='FV/admin/2027',
+            issue_date='2027-07-24',
+            amount=Decimal('1.00'),
+            invoice_type=Invoice.Type.NON_ACCOUNTING_RECEIPT,
+            attachment='invoices/admin.pdf',
+            description='Admin approval',
+            internal_number=None,
+            status=Invoice.Status.APPROVED,
+        )
+        request = RequestFactory().post('/')
+        request.user = self.admin
+
+        InvoiceAdmin(Invoice, AdminSite()).save_model(
+            request,
+            invoice,
+            form=None,
+            change=True,
+        )
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.internal_number, 'WWW_2027_FPZ_0001')
+
+    def test_admin_can_reject_numbered_invoice(self):
+        self.invoice.status = Invoice.Status.REJECTED
+        request = RequestFactory().post('/')
+        request.user = self.admin
+
+        InvoiceAdmin(Invoice, AdminSite()).save_model(
+            request,
+            self.invoice,
+            form=None,
+            change=True,
+        )
+
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, Invoice.Status.REJECTED)
+        self.assertEqual(self.invoice.internal_number, 'WWW_2026_FP_0001')
+
     def test_invoice_with_cost_items_is_protected_from_deletion(self):
         CostItem.objects.create(invoice=self.invoice, amount=Decimal('10.00'),
                                 category=CostItem.Category.WORKSHOPS)
@@ -234,12 +276,49 @@ class CostModelTests(TestCase):
         received.refresh_from_db()
         self.assertEqual(received.status, Invoice.Status.RECEIVED)
 
+    def test_approval_allocates_numbers_from_the_invoice_type_series(self):
+        camp = Camp.objects.create(year=2028)
+        expected_numbers = (
+            (Invoice.Type.KSEF, 'WWW_2028_FP_0001'),
+            (Invoice.Type.NON_ACCOUNTING_RECEIPT, 'WWW_2028_FPZ_0001'),
+            (Invoice.Type.RECEIPT_WITH_NIP, 'WWW_2028_FP_0002'),
+        )
+
+        for index, (invoice_type, expected_number) in enumerate(expected_numbers):
+            invoice = Invoice.objects.create(
+                user=self.user,
+                camp=camp,
+                attachment=f'invoices/{index}.pdf',
+                document_number=f'FV/{index}/2028',
+                issue_date='2028-07-24',
+                amount=Decimal('10.00'),
+                invoice_type=invoice_type,
+                description='Approval numbering test',
+                internal_number='',
+            )
+
+            transition_invoices(
+                invoices=Invoice.objects.filter(pk=invoice.pk),
+                target_status=Invoice.Status.APPROVED,
+                changed_by=self.admin,
+            )
+
+            invoice.refresh_from_db()
+            self.assertEqual(invoice.internal_number, expected_number)
+
+        self.assertEqual(
+            set(InvoiceSequence.objects.filter(camp=camp).values_list(
+                'series',
+                'last_allocated',
+            )),
+            {('FP', 2), ('FPZ', 1)},
+        )
+
     def test_transition_allows_only_the_defined_state_graph(self):
         allowed = {
             (Invoice.Status.RECEIVED, Invoice.Status.APPROVED),
             (Invoice.Status.RECEIVED, Invoice.Status.REJECTED),
             (Invoice.Status.APPROVED, Invoice.Status.PROCESSED),
-            (Invoice.Status.APPROVED, Invoice.Status.REJECTED),
             (Invoice.Status.REJECTED, Invoice.Status.APPROVED),
         }
 

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -579,6 +579,24 @@ class OwnCostsViewsTests(TestCase):
         self.assertEqual(invoice.user, self.user)
         self.assertEqual(invoice.cost_items.get().amount, Decimal('10.00'))
 
+    def test_invoice_add_uses_non_accounting_receipt_numbering(self):
+        SettlementDetails.objects.create(
+            user=self.user,
+            camp=self.camp,
+            account_number='PL61109010140000071219812874',
+        )
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse('costs_invoice_add', args=[self.camp.pk]), {
+            **self.invoice_post_data(invoice_type=Invoice.Type.NON_ACCOUNTING_RECEIPT),
+            'attachment': SimpleUploadedFile(
+                'receipt.pdf', b'%PDF-1.7', content_type='application/pdf'
+            ),
+        })
+
+        self.assertRedirects(response, reverse('costs_mine', args=[self.camp.pk]))
+        self.assertTrue(Invoice.objects.filter(internal_number='WWW_2026_FPZ_0001').exists())
+
     def test_rejected_invoice_edit_resets_it_to_received(self):
         SettlementDetails.objects.create(
             user=self.user,

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from freezegun import freeze_time
 
 from wwwapp.forms import (
     CostItemForm,
@@ -138,6 +139,18 @@ class InvoiceFormTests(TestCase):
 
                 self.assertFalse(form.is_valid())
                 self.assertIn('attachment', form.errors)
+
+    def test_numbered_invoice_type_cannot_be_changed(self):
+        form = InvoiceForm(
+            data={**self.data, 'invoice_type': Invoice.Type.NON_ACCOUNTING_RECEIPT},
+            instance=self.invoice,
+            user=self.user,
+            camp=self.camp,
+        )
+
+        self.assertTrue(form.is_valid())
+        invoice = form.save()
+        self.assertEqual(invoice.invoice_type, Invoice.Type.KSEF)
 
     def test_cost_item_formset_rejects_unequal_total(self):
         formset = CostItemFormSet(
@@ -559,27 +572,44 @@ class OwnCostsViewsTests(TestCase):
         self.assertContains(response, 'Suma pozycji kosztowych musi być równa kwocie faktury.')
         self.assertContains(response, 'data-fill-remaining-cost-item')
 
-    def test_invoice_add_creates_invoice_with_a_cost_item(self):
+    @freeze_time('2026-08-09 12:34:56.123456')
+    def test_invoice_add_creates_unnumbered_invoice_with_internal_attachment_name(self):
         SettlementDetails.objects.create(
             user=self.user,
             camp=self.camp,
             account_number='PL61109010140000071219812874',
         )
         self.client.force_login(self.user)
+        field = Invoice._meta.get_field('attachment')
+        original_storage = field.storage
 
-        response = self.client.post(reverse('costs_invoice_add', args=[self.camp.pk]), {
-            **self.invoice_post_data(),
-            'attachment': SimpleUploadedFile(
-                'invoice.pdf', b'%PDF-1.7', content_type='application/pdf'
-            ),
-        })
+        with TemporaryDirectory() as sendfile_root:
+            with override_settings(SENDFILE_ROOT=sendfile_root):
+                field.storage = UploadStorage()
+                try:
+                    response = self.client.post(
+                        reverse('costs_invoice_add', args=[self.camp.pk]),
+                        {
+                            **self.invoice_post_data(),
+                            'attachment': SimpleUploadedFile(
+                                'invoice.pdf', b'%PDF-1.7', content_type='application/pdf'
+                            ),
+                        },
+                    )
+                finally:
+                    field.storage = original_storage
 
-        self.assertRedirects(response, reverse('costs_mine', args=[self.camp.pk]))
-        invoice = Invoice.objects.get(internal_number='WWW_2026_FP_0002')
-        self.assertEqual(invoice.user, self.user)
-        self.assertEqual(invoice.cost_items.get().amount, Decimal('10.00'))
+                self.assertRedirects(response, reverse('costs_mine', args=[self.camp.pk]))
+                invoice = Invoice.objects.get(document_number='FV/2/2026')
+                self.assertEqual(invoice.user, self.user)
+                self.assertIsNone(invoice.internal_number)
+                self.assertEqual(
+                    invoice.attachment.name,
+                    'invoices/WWW_2026_20260809123456123456.pdf',
+                )
+                self.assertEqual(invoice.cost_items.get().amount, Decimal('10.00'))
 
-    def test_invoice_add_uses_non_accounting_receipt_numbering(self):
+    def test_invoice_add_does_not_allocate_non_accounting_receipt_number(self):
         SettlementDetails.objects.create(
             user=self.user,
             camp=self.camp,
@@ -595,7 +625,12 @@ class OwnCostsViewsTests(TestCase):
         })
 
         self.assertRedirects(response, reverse('costs_mine', args=[self.camp.pk]))
-        self.assertTrue(Invoice.objects.filter(internal_number='WWW_2026_FPZ_0001').exists())
+        invoice = Invoice.objects.get(document_number='FV/2/2026')
+        self.assertIsNone(invoice.internal_number)
+        self.assertFalse(InvoiceSequence.objects.filter(
+            camp=self.camp,
+            series=InvoiceSequence.Series.FPZ,
+        ).exists())
 
     def test_rejected_invoice_edit_resets_it_to_received(self):
         SettlementDetails.objects.create(
@@ -727,6 +762,39 @@ class OwnCostsViewsTests(TestCase):
         response = self.client.get(reverse('costs_invoice_attachment', args=[self.camp.pk, self.invoice.pk]))
 
         self.assertEqual(response.status_code, 200)
+
+    @patch('wwwapp.views.sendfile', return_value=HttpResponse())
+    def test_approved_invoice_download_uses_invoice_number(self, sendfile_mock):
+        self.invoice.status = Invoice.Status.APPROVED
+        self.invoice.save(update_fields=['status'])
+        self.client.force_login(self.user)
+
+        self.client.get(reverse(
+            'costs_invoice_attachment',
+            args=[self.camp.pk, self.invoice.pk],
+        ))
+
+        self.assertEqual(
+            sendfile_mock.call_args.kwargs['attachment_filename'],
+            'WWW_2026_FP_0001.pdf',
+        )
+
+    @patch('wwwapp.views.sendfile', return_value=HttpResponse())
+    def test_unnumbered_invoice_download_uses_internal_filename(self, sendfile_mock):
+        self.invoice.internal_number = None
+        self.invoice.attachment = 'invoices/WWW_2026_20260809123456123456.pdf'
+        self.invoice.save(update_fields=['internal_number', 'attachment'])
+        self.client.force_login(self.user)
+
+        self.client.get(reverse(
+            'costs_invoice_attachment',
+            args=[self.camp.pk, self.invoice.pk],
+        ))
+
+        self.assertEqual(
+            sendfile_mock.call_args.kwargs['attachment_filename'],
+            'WWW_2026_20260809123456123456.pdf',
+        )
 
     @patch('wwwapp.views.sendfile', return_value=HttpResponse())
     def test_only_all_costs_permission_can_get_another_users_attachment(self, _sendfile_response):
@@ -972,6 +1040,22 @@ class CostAdministrationViewsTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.received_invoice.refresh_from_db()
         self.assertEqual(self.received_invoice.status, Invoice.Status.RECEIVED)
+
+    def test_approved_invoice_cannot_be_rejected(self):
+        self.client.force_login(self.admin)
+
+        response = self.client.post(
+            reverse('costs_admin_transition', args=[self.camp.pk]),
+            {
+                'invoice_ids': [self.approved_invoice.pk],
+                'status': Invoice.Status.REJECTED,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.approved_invoice.refresh_from_db()
+        self.assertEqual(self.approved_invoice.status, Invoice.Status.APPROVED)
+        self.assertEqual(self.approved_invoice.internal_number, 'WWW_2026_FP_0002')
 
     def test_processed_transition_requires_processing_permission(self):
         self.client.force_login(self.admin)

--- a/wwwapp/tests/test_invoice_numbering_migration.py
+++ b/wwwapp/tests/test_invoice_numbering_migration.py
@@ -30,12 +30,16 @@ class InvoiceNumberingMigrationTests(TransactionTestCase):
         Invoice = self.apps.get_model('wwwapp', 'Invoice')
         InvoiceSequence = self.apps.get_model('wwwapp', 'InvoiceSequence')
 
-        numbers_by_type = dict(Invoice.objects.values_list('invoice_type', 'internal_number'))
+        numbers_by_document = dict(Invoice.objects.values_list(
+            'document_number',
+            'internal_number',
+        ))
 
-        self.assertEqual(numbers_by_type, {
-            'KSEF': 'WWW_2026_FP_0001',
-            'NON_ACCOUNTING_RECEIPT': 'WWW_2026_FPZ_0001',
-            'RECEIPT_WITH_NIP': 'WWW_2026_FP_0002',
+        self.assertEqual(numbers_by_document, {
+            'TEST/1/2026': 'WWW_2026_FP_0001',
+            'TEST/2/2026': None,
+            'TEST/3/2026': 'WWW_2026_FPZ_0001',
+            'TEST/4/2026': 'WWW_2026_FP_0002',
         })
         self.assertEqual(
             set(InvoiceSequence.objects.filter(camp_id=2026).values_list(
@@ -52,8 +56,14 @@ class InvoiceNumberingMigrationTests(TransactionTestCase):
         InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
         user = User.objects.create(username='migration-user')
         camp, _ = Camp.objects.get_or_create(year=2026)
-        for sequence, invoice_type in enumerate(
-            ('KSEF', 'NON_ACCOUNTING_RECEIPT', 'RECEIPT_WITH_NIP'),
+        invoice_data = (
+            ('KSEF', 'APPROVED'),
+            ('NON_ACCOUNTING_RECEIPT', 'RECEIVED'),
+            ('NON_ACCOUNTING_RECEIPT', 'APPROVED'),
+            ('RECEIPT_WITH_NIP', 'PROCESSED'),
+        )
+        for sequence, (invoice_type, status) in enumerate(
+            invoice_data,
             start=1,
         ):
             Invoice.objects.create(
@@ -64,7 +74,8 @@ class InvoiceNumberingMigrationTests(TransactionTestCase):
                 issue_date='2026-07-24',
                 amount='10.00',
                 invoice_type=invoice_type,
+                status=status,
                 description='Migration test',
                 internal_number=f'WWW_2026_FP_{sequence:04d}',
             )
-        InvoiceSequence.objects.create(camp=camp, last_allocated=3)
+        InvoiceSequence.objects.create(camp=camp, last_allocated=4)

--- a/wwwapp/tests/test_invoice_numbering_migration.py
+++ b/wwwapp/tests/test_invoice_numbering_migration.py
@@ -1,0 +1,70 @@
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class InvoiceNumberingMigrationTests(TransactionTestCase):
+    migrate_from = [(
+        'wwwapp',
+        '0091_costitem_invoice_invoicesequence_reimbursement_settlementdetails',
+    )]
+    migrate_to = [('wwwapp', '0092_separate_invoice_numbering_series')]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self._create_old_invoices(old_apps)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def test_existing_invoices_are_renumbered_with_independent_series(self):
+        Invoice = self.apps.get_model('wwwapp', 'Invoice')
+        InvoiceSequence = self.apps.get_model('wwwapp', 'InvoiceSequence')
+
+        numbers_by_type = dict(Invoice.objects.values_list('invoice_type', 'internal_number'))
+
+        self.assertEqual(numbers_by_type, {
+            'KSEF': 'WWW_2026_FP_0001',
+            'NON_ACCOUNTING_RECEIPT': 'WWW_2026_FPZ_0001',
+            'RECEIPT_WITH_NIP': 'WWW_2026_FP_0002',
+        })
+        self.assertEqual(
+            set(InvoiceSequence.objects.filter(camp_id=2026).values_list(
+                'series',
+                'last_allocated',
+            )),
+            {('FP', 2), ('FPZ', 1)},
+        )
+
+    def _create_old_invoices(self, apps):
+        User = apps.get_model('auth', 'User')
+        Camp = apps.get_model('wwwapp', 'Camp')
+        Invoice = apps.get_model('wwwapp', 'Invoice')
+        InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+        user = User.objects.create(username='migration-user')
+        camp, _ = Camp.objects.get_or_create(year=2026)
+        for sequence, invoice_type in enumerate(
+            ('KSEF', 'NON_ACCOUNTING_RECEIPT', 'RECEIPT_WITH_NIP'),
+            start=1,
+        ):
+            Invoice.objects.create(
+                user=user,
+                camp=camp,
+                attachment=f'invoices/{sequence}.pdf',
+                document_number=f'TEST/{sequence}/2026',
+                issue_date='2026-07-24',
+                amount='10.00',
+                invoice_type=invoice_type,
+                description='Migration test',
+                internal_number=f'WWW_2026_FP_{sequence:04d}',
+            )
+        InvoiceSequence.objects.create(camp=camp, last_allocated=3)

--- a/wwwapp/tests/test_populate_with_test_data.py
+++ b/wwwapp/tests/test_populate_with_test_data.py
@@ -27,4 +27,8 @@ class PopulateWithTestData(TestCase):
         self.assertEqual(set(invoices.values_list('status', flat=True)), set(Invoice.Status.values))
         self.assertEqual(invoices.values('user_id').distinct().count(), len(Invoice.Status.values))
         sequence = InvoiceSequence.objects.get(camp=invoices.first().camp)
-        self.assertEqual(sequence.last_allocated, len(Invoice.Status.values))
+        self.assertEqual(sequence.last_allocated, 2)
+        self.assertEqual(
+            invoices.filter(internal_number__isnull=False).values('status').distinct().count(),
+            2,
+        )

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -224,10 +224,9 @@ def _invoice_form_view(request, *, year, invoice_id=None, admin_edit=False):
                 invoice.admin_modified_by = None
         uploaded_attachment = invoice_form.cleaned_data['attachment']
         if isinstance(uploaded_attachment, UploadedFile):
-            invoice.attachment.name = _invoice_attachment_name(
-                camp=camp,
-                original_name=uploaded_attachment.name,
-            )
+            _, extension = os.path.splitext(uploaded_attachment.name)
+            timestamp = timezone.now().strftime('%Y%m%d%H%M%S%f')
+            invoice.attachment.name = f'WWW_{camp.year}_{timestamp}{extension.lower()}'
         stored_attachment_name = ''
         try:
             with transaction.atomic():
@@ -281,13 +280,6 @@ def costs_invoice_attachment_view(request, year, invoice_id):
         invoice.attachment.path,
         attachment_filename=attachment_filename,
     )
-
-
-def _invoice_attachment_name(*, camp, original_name):
-    _, extension = os.path.splitext(original_name)
-    timestamp = timezone.now().strftime('%Y%m%d%H%M%S%f')
-    return f'WWW_{camp.year}_{timestamp}{extension.lower()}'
-
 
 @login_required
 @permission_required('wwwapp.view_all_costs', raise_exception=True)

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -215,7 +215,10 @@ def _invoice_form_view(request, *, year, invoice_id=None, admin_edit=False):
         old_attachment_name = invoice.attachment.name if invoice else ''
         invoice = invoice_form.save(commit=False)
         if invoice_id is None:
-            invoice.internal_number = allocate_invoice_number(camp=camp)
+            invoice.internal_number = allocate_invoice_number(
+                camp=camp,
+                invoice_type=invoice.invoice_type,
+            )
         else:
             if admin_edit:
                 invoice.admin_modified_at = timezone.now()

--- a/wwwapp/views.py
+++ b/wwwapp/views.py
@@ -37,7 +37,6 @@ from django_sendfile import sendfile
 
 from wwwforms.models import Form, FormQuestionAnswer, FormQuestion
 from wwwapp.costs import (
-    allocate_invoice_number,
     approved_total_for,
     balance_for,
     invoice_csv_response,
@@ -214,12 +213,7 @@ def _invoice_form_view(request, *, year, invoice_id=None, admin_edit=False):
     if request.method == 'POST' and invoice_form_is_valid and formset.is_valid():
         old_attachment_name = invoice.attachment.name if invoice else ''
         invoice = invoice_form.save(commit=False)
-        if invoice_id is None:
-            invoice.internal_number = allocate_invoice_number(
-                camp=camp,
-                invoice_type=invoice.invoice_type,
-            )
-        else:
+        if invoice_id is not None:
             if admin_edit:
                 invoice.admin_modified_at = timezone.now()
                 invoice.admin_modified_by = request.user
@@ -230,8 +224,10 @@ def _invoice_form_view(request, *, year, invoice_id=None, admin_edit=False):
                 invoice.admin_modified_by = None
         uploaded_attachment = invoice_form.cleaned_data['attachment']
         if isinstance(uploaded_attachment, UploadedFile):
-            _, extension = os.path.splitext(uploaded_attachment.name)
-            invoice.attachment.name = f'{invoice.internal_number}{extension.lower()}'
+            invoice.attachment.name = _invoice_attachment_name(
+                camp=camp,
+                original_name=uploaded_attachment.name,
+            )
         stored_attachment_name = ''
         try:
             with transaction.atomic():
@@ -273,7 +269,24 @@ def costs_invoice_attachment_view(request, year, invoice_id):
     if invoice.user_id != request.user.id and not request.user.has_perm('wwwapp.view_all_costs'):
         raise Http404
 
-    return sendfile(request, invoice.attachment.path)
+    internal_filename = os.path.basename(invoice.attachment.name)
+    _, extension = os.path.splitext(internal_filename)
+    attachment_filename = (
+        f'{invoice.internal_number}{extension}'
+        if invoice.internal_number
+        else internal_filename
+    )
+    return sendfile(
+        request,
+        invoice.attachment.path,
+        attachment_filename=attachment_filename,
+    )
+
+
+def _invoice_attachment_name(*, camp, original_name):
+    _, extension = os.path.splitext(original_name)
+    timestamp = timezone.now().strftime('%Y%m%d%H%M%S%f')
+    return f'WWW_{camp.year}_{timestamp}{extension.lower()}'
 
 
 @login_required


### PR DESCRIPTION
## What changed

- Keep separate FP and FPZ counters for each camp. Non-accounting receipts use FPZ; other invoice types use FP.
- Allocate invoice numbers only when invoices are approved. Internal numbers remain empty before approval.
- Renumber approved and processed invoices during migration, and clear numbers from invoices that are not approved.
- Disallow approved-to-rejected transitions in the costs panel. Django admin keeps its existing ability to reject invoices.
- Store uploads under timestamp-based internal names such as WWW_2026_20260809123456789012.pdf.
- Return numbered download filenames for approved invoices and internal filenames for unnumbered invoices.
- Cover numbering, approval, transitions, migration, uploads, downloads, and development fixtures with tests.

## Validation

- .venv/bin/python manage.py test -v 2 (304 tests)
- .venv/bin/python manage.py makemigrations --check --dry-run
- git diff --check

<!-- Reviewable:start -->
- - -
This change is [Reviewable](https://reviewable.io/reviews/warsztatywww/aplikacjawww/706)
<!-- Reviewable:end -->