### PR TITLE
Fix PostgreSQL invoice numbering migration

### DIFF
--- a/wwwapp/migrations/0093_alter_invoicesequence_series.py
+++ b/wwwapp/migrations/0093_alter_invoicesequence_series.py
@@ -3,96 +3,6 @@
 from django.db import migrations, models
 
 
-INVOICE_TYPE_PREFIXES = {
-    'KSEF': 'K',
-    'OUTSIDE_KSEF': 'L',
-    'RECEIPT_WITH_NIP': 'P',
-    'NON_ACCOUNTING_RECEIPT': 'NP',
-}
-NUMBERED_STATUSES = ('APPROVED', 'PROCESSED')
-
-
-def renumber_invoices_by_type(apps, schema_editor):
-    Invoice = apps.get_model('wwwapp', 'Invoice')
-    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
-    database = schema_editor.connection.alias
-    invoices = list(
-        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
-    )
-
-    _replace_numbers_with_temporary_values(invoices, database)
-    allocated = {}
-    for invoice in invoices:
-        if invoice.status not in NUMBERED_STATUSES:
-            invoice.internal_number = None
-            invoice.save(using=database, update_fields=['internal_number'])
-            continue
-        prefix = INVOICE_TYPE_PREFIXES[invoice.invoice_type]
-        key = (invoice.camp_id, invoice.invoice_type)
-        allocated[key] = allocated.get(key, 0) + 1
-        invoice.internal_number = (
-            f'WWW_{invoice.camp_id}_{prefix}_{allocated[key]:04d}'
-        )
-        invoice.save(using=database, update_fields=['internal_number'])
-
-    camp_ids = set(invoice.camp_id for invoice in invoices)
-    camp_ids.update(
-        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
-    )
-    InvoiceSequence.objects.using(database).all().delete()
-    for camp_id in camp_ids:
-        for invoice_type in INVOICE_TYPE_PREFIXES:
-            InvoiceSequence.objects.using(database).create(
-                camp_id=camp_id,
-                series=invoice_type,
-                last_allocated=allocated.get((camp_id, invoice_type), 0),
-            )
-
-
-def restore_two_invoice_series(apps, schema_editor):
-    Invoice = apps.get_model('wwwapp', 'Invoice')
-    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
-    database = schema_editor.connection.alias
-    invoices = list(
-        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
-    )
-
-    _replace_numbers_with_temporary_values(invoices, database)
-    allocated = {}
-    for invoice in invoices:
-        if invoice.status not in NUMBERED_STATUSES:
-            invoice.internal_number = None
-            invoice.save(using=database, update_fields=['internal_number'])
-            continue
-        series = 'FPZ' if invoice.invoice_type == 'NON_ACCOUNTING_RECEIPT' else 'FP'
-        key = (invoice.camp_id, series)
-        allocated[key] = allocated.get(key, 0) + 1
-        invoice.internal_number = (
-            f'WWW_{invoice.camp_id}_{series}_{allocated[key]:04d}'
-        )
-        invoice.save(using=database, update_fields=['internal_number'])
-
-    camp_ids = set(invoice.camp_id for invoice in invoices)
-    camp_ids.update(
-        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
-    )
-    InvoiceSequence.objects.using(database).all().delete()
-    for camp_id in camp_ids:
-        for series in ('FP', 'FPZ'):
-            InvoiceSequence.objects.using(database).create(
-                camp_id=camp_id,
-                series=series,
-                last_allocated=allocated.get((camp_id, series), 0),
-            )
-
-
-def _replace_numbers_with_temporary_values(invoices, database):
-    for invoice in invoices:
-        if invoice.internal_number is not None:
-            invoice.internal_number = f'__invoice_renumber_{invoice.pk}'
-            invoice.save(using=database, update_fields=['internal_number'])
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -112,10 +22,6 @@ class Migration(migrations.Migration):
                 ],
                 max_length=24,
             ),
-        ),
-        migrations.RunPython(
-            renumber_invoices_by_type,
-            restore_two_invoice_series,
         ),
         migrations.RemoveConstraint(
             model_name='invoicesequence',

--- a/wwwapp/migrations/0094_renumber_invoices_by_type.py
+++ b/wwwapp/migrations/0094_renumber_invoices_by_type.py
@@ -1,0 +1,104 @@
+from django.db import migrations
+
+
+INVOICE_TYPE_PREFIXES = {
+    'KSEF': 'K',
+    'OUTSIDE_KSEF': 'L',
+    'RECEIPT_WITH_NIP': 'P',
+    'NON_ACCOUNTING_RECEIPT': 'NP',
+}
+NUMBERED_STATUSES = ('APPROVED', 'PROCESSED')
+
+
+def renumber_invoices_by_type(apps, schema_editor):
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+    database = schema_editor.connection.alias
+    invoices = list(
+        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
+    )
+
+    _replace_numbers_with_temporary_values(invoices, database)
+    allocated = {}
+    for invoice in invoices:
+        if invoice.status not in NUMBERED_STATUSES:
+            invoice.internal_number = None
+            invoice.save(using=database, update_fields=['internal_number'])
+            continue
+        prefix = INVOICE_TYPE_PREFIXES[invoice.invoice_type]
+        key = (invoice.camp_id, invoice.invoice_type)
+        allocated[key] = allocated.get(key, 0) + 1
+        invoice.internal_number = (
+            f'WWW_{invoice.camp_id}_{prefix}_{allocated[key]:04d}'
+        )
+        invoice.save(using=database, update_fields=['internal_number'])
+
+    camp_ids = set(invoice.camp_id for invoice in invoices)
+    camp_ids.update(
+        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
+    )
+    InvoiceSequence.objects.using(database).all().delete()
+    for camp_id in camp_ids:
+        for invoice_type in INVOICE_TYPE_PREFIXES:
+            InvoiceSequence.objects.using(database).create(
+                camp_id=camp_id,
+                invoice_type=invoice_type,
+                last_allocated=allocated.get((camp_id, invoice_type), 0),
+            )
+
+
+def restore_two_invoice_series(apps, schema_editor):
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+    database = schema_editor.connection.alias
+    invoices = list(
+        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
+    )
+
+    _replace_numbers_with_temporary_values(invoices, database)
+    allocated = {}
+    for invoice in invoices:
+        if invoice.status not in NUMBERED_STATUSES:
+            invoice.internal_number = None
+            invoice.save(using=database, update_fields=['internal_number'])
+            continue
+        series = 'FPZ' if invoice.invoice_type == 'NON_ACCOUNTING_RECEIPT' else 'FP'
+        key = (invoice.camp_id, series)
+        allocated[key] = allocated.get(key, 0) + 1
+        invoice.internal_number = (
+            f'WWW_{invoice.camp_id}_{series}_{allocated[key]:04d}'
+        )
+        invoice.save(using=database, update_fields=['internal_number'])
+
+    camp_ids = set(invoice.camp_id for invoice in invoices)
+    camp_ids.update(
+        InvoiceSequence.objects.using(database).values_list('camp_id', flat=True)
+    )
+    InvoiceSequence.objects.using(database).all().delete()
+    for camp_id in camp_ids:
+        for series in ('FP', 'FPZ'):
+            InvoiceSequence.objects.using(database).create(
+                camp_id=camp_id,
+                invoice_type=series,
+                last_allocated=allocated.get((camp_id, series), 0),
+            )
+
+
+def _replace_numbers_with_temporary_values(invoices, database):
+    for invoice in invoices:
+        if invoice.internal_number is not None:
+            invoice.internal_number = f'__invoice_renumber_{invoice.pk}'
+            invoice.save(using=database, update_fields=['internal_number'])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('wwwapp', '0093_alter_invoicesequence_series'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            renumber_invoices_by_type,
+            restore_two_invoice_series,
+        ),
+    ]

--- a/wwwapp/tests/test_invoice_numbering_migration.py
+++ b/wwwapp/tests/test_invoice_numbering_migration.py
@@ -83,7 +83,7 @@ class InvoiceNumberingMigrationTests(TransactionTestCase):
 
 class InvoiceTypeNumberingMigrationTests(TransactionTestCase):
     migrate_from = [('wwwapp', '0092_separate_invoice_numbering_series')]
-    migrate_to = [('wwwapp', '0093_alter_invoicesequence_series')]
+    migrate_to = [('wwwapp', '0094_renumber_invoices_by_type')]
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Summary

- keep the invoice sequence schema changes in migration 0093
- move invoice renumbering and sequence rebuilding to migration 0094
- update the migration test to cover the complete schema and data migration chain

## Reason

PostgreSQL defers foreign-key trigger checks for the sequence rows created by the
data migration. Running later `ALTER TABLE` operations in the same atomic migration
therefore fails with `cannot ALTER TABLE ... because it has pending trigger events`.
Separating schema and data operations gives them separate migration transactions.

## Verification

- 97 focused invoice, cost, fixture, and migration tests pass
- `manage.py makemigrations --check --dry-run` reports no changes
- PostgreSQL 15 migration succeeds from an empty database
- PostgreSQL 15 rollback from 0094 to 0092 succeeds, followed by reapplication
- PostgreSQL 15 upgrade from the previously applied 0093 to 0094 succeeds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/708)
<!-- Reviewable:end -->
