### PR TITLE
Use shared FVP invoice numbering

### DIFF
--- a/wwwapp/costs.py
+++ b/wwwapp/costs.py
@@ -3,12 +3,13 @@
 import csv
 from decimal import Decimal
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
-from django.db.models import Sum
+from django.db import transaction
+from django.db.models import IntegerField, Max, Sum
+from django.db.models.functions import Cast, Substr
 from django.http import HttpResponse
 from django.utils import timezone
 
-from wwwapp.models import Invoice, InvoiceSequence, Reimbursement
+from wwwapp.models import Camp, Invoice, Reimbursement
 
 
 CSV_FIELDS = (
@@ -25,32 +26,27 @@ CSV_FIELDS = (
     'description',
 )
 
+INVOICE_SERIES = {
+    Invoice.Type.KSEF: 'K',
+    Invoice.Type.OUTSIDE_KSEF: 'FVP',
+    Invoice.Type.RECEIPT_WITH_NIP: 'FVP',
+    Invoice.Type.NON_ACCOUNTING_RECEIPT: 'NP',
+}
+
 
 @transaction.atomic
 def allocate_invoice_number(*, camp, invoice_type):
     """Allocate the next internal invoice number for a workshop edition."""
-    prefix = {
-        Invoice.Type.KSEF: 'K',
-        Invoice.Type.OUTSIDE_KSEF: 'L',
-        Invoice.Type.RECEIPT_WITH_NIP: 'P',
-        Invoice.Type.NON_ACCOUNTING_RECEIPT: 'NP',
-    }[invoice_type]
-    try:
-        with transaction.atomic():
-            sequence, created = InvoiceSequence.objects.get_or_create(
-                camp=camp,
-                invoice_type=invoice_type,
-            )
-    except IntegrityError:
-        created = False
-    if not created:
-        sequence = InvoiceSequence.objects.select_for_update().get(
-            camp=camp,
-            invoice_type=invoice_type,
-        )
-    sequence.last_allocated += 1
-    sequence.save(update_fields=['last_allocated'])
-    return f'WWW_{camp.year}_{prefix}_{sequence.last_allocated:04d}'
+    Camp.objects.select_for_update().get(pk=camp.pk)
+    series = INVOICE_SERIES[invoice_type]
+    prefix = f'WWW_{camp.year}_{series}_'
+    last_allocated = Invoice.objects.filter(
+        camp=camp,
+        internal_number__startswith=prefix,
+    ).aggregate(
+        value=Max(Cast(Substr('internal_number', len(prefix) + 1), IntegerField())),
+    )['value']
+    return f'{prefix}{(last_allocated or 0) + 1:04d}'
 
 
 @transaction.atomic

--- a/wwwapp/management/commands/populate_with_test_data.py
+++ b/wwwapp/management/commands/populate_with_test_data.py
@@ -12,7 +12,6 @@ from wwwapp.models import (
     CampParticipant,
     CostItem,
     Invoice,
-    InvoiceSequence,
     SettlementDetails,
     Solution,
     UserProfile,
@@ -652,12 +651,6 @@ class Command(BaseCommand):
                 amount=amount,
                 category=CostItem.Category.REGULAR_PURCHASES,
             )
-        InvoiceSequence.objects.create(
-            camp=current_camp,
-            invoice_type=Invoice.Type.KSEF,
-            last_allocated=last_allocated,
-        )
-
         self.debug_print(
             f"Data population complete. Created {len(all_workshops)} total workshops across {len(camp_years)} years.")
         self.debug_print(

--- a/wwwapp/migrations/0095_renumber_invoices_to_fvp_and_remove_invoicesequence.py
+++ b/wwwapp/migrations/0095_renumber_invoices_to_fvp_and_remove_invoicesequence.py
@@ -1,0 +1,86 @@
+"""Renumber invoices into K, FVP, and NP series and remove stored counters."""
+
+from django.db import migrations
+
+
+NUMBERED_STATUSES = ('APPROVED', 'PROCESSED')
+NEW_SERIES_BY_TYPE = {
+    'KSEF': 'K',
+    'OUTSIDE_KSEF': 'FVP',
+    'RECEIPT_WITH_NIP': 'FVP',
+    'NON_ACCOUNTING_RECEIPT': 'NP',
+}
+OLD_SERIES_BY_TYPE = {
+    'KSEF': 'K',
+    'OUTSIDE_KSEF': 'L',
+    'RECEIPT_WITH_NIP': 'P',
+    'NON_ACCOUNTING_RECEIPT': 'NP',
+}
+
+
+def renumber_invoices_to_fvp(apps, schema_editor):
+    """Apply the K, FVP, and NP numbering rule to stored invoices."""
+    _renumber_invoices(apps, schema_editor, NEW_SERIES_BY_TYPE)
+
+
+def restore_invoice_type_series(apps, schema_editor):
+    """Restore the four per-type series used by migration 0094."""
+    allocated = _renumber_invoices(apps, schema_editor, OLD_SERIES_BY_TYPE)
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+    database = schema_editor.connection.alias
+    camp_ids = Invoice.objects.using(database).values_list('camp_id', flat=True).distinct()
+
+    for camp_id in camp_ids:
+        for invoice_type in OLD_SERIES_BY_TYPE:
+            series = OLD_SERIES_BY_TYPE[invoice_type]
+            InvoiceSequence.objects.using(database).create(
+                camp_id=camp_id,
+                invoice_type=invoice_type,
+                last_allocated=allocated.get((camp_id, series), 0),
+            )
+
+
+def _renumber_invoices(apps, schema_editor, series_by_type):
+    Invoice = apps.get_model('wwwapp', 'Invoice')
+    database = schema_editor.connection.alias
+    invoices = list(
+        Invoice.objects.using(database).order_by('camp_id', 'created_at', 'pk')
+    )
+    _replace_numbers_with_temporary_values(invoices, database)
+
+    allocated = {}
+    for invoice in invoices:
+        if invoice.status not in NUMBERED_STATUSES:
+            invoice.internal_number = None
+            invoice.save(using=database, update_fields=['internal_number'])
+            continue
+        series = series_by_type[invoice.invoice_type]
+        key = (invoice.camp_id, series)
+        allocated[key] = allocated.get(key, 0) + 1
+        invoice.internal_number = (
+            f'WWW_{invoice.camp_id}_{series}_{allocated[key]:04d}'
+        )
+        invoice.save(using=database, update_fields=['internal_number'])
+    return allocated
+
+
+def _replace_numbers_with_temporary_values(invoices, database):
+    for invoice in invoices:
+        if invoice.internal_number is not None:
+            invoice.internal_number = f'__invoice_renumber_{invoice.pk}'
+            invoice.save(using=database, update_fields=['internal_number'])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('wwwapp', '0094_renumber_invoices_by_type'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            renumber_invoices_to_fvp,
+            restore_invoice_type_series,
+        ),
+        migrations.DeleteModel(name='InvoiceSequence'),
+    ]

--- a/wwwapp/models.py
+++ b/wwwapp/models.py
@@ -650,24 +650,6 @@ class Invoice(models.Model):
         )
 
 
-class InvoiceSequence(models.Model):
-    camp = models.ForeignKey(
-        Camp,
-        on_delete=models.PROTECT,
-        related_name='invoice_sequences',
-    )
-    invoice_type = models.CharField(max_length=24, choices=Invoice.Type.choices)
-    last_allocated = models.PositiveIntegerField(default=0)
-
-    class Meta:
-        constraints = (
-            models.UniqueConstraint(
-                fields=('camp', 'invoice_type'),
-                name='unique_invoice_sequence_type_per_camp',
-            ),
-        )
-
-
 class CostItem(models.Model):
     class Category(models.TextChoices):
         WORKSHOPS = 'WORKSHOPS', 'Warsztaty'

--- a/wwwapp/tests/test_costs_models.py
+++ b/wwwapp/tests/test_costs_models.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-from unittest.mock import patch
-
 from django.contrib.auth.models import User
 from django.contrib.admin.sites import AdminSite
 from django.core.exceptions import ValidationError
@@ -12,7 +10,6 @@ from wwwapp.models import (
     Camp,
     CostItem,
     Invoice,
-    InvoiceSequence,
     Reimbursement,
     SettlementDetails,
     Workshop,
@@ -56,11 +53,6 @@ class CostModelTests(TestCase):
             attachment='invoices/fv-1.pdf',
             description='Materiały do warsztatów',
             internal_number='WWW_2026_K_0001',
-        )
-        InvoiceSequence.objects.create(
-            camp=self.camp,
-            invoice_type=Invoice.Type.KSEF,
-            last_allocated=1,
         )
         workshop_type = WorkshopType.objects.create(year=self.other_camp, name='Type')
         self.other_workshop = Workshop.objects.create(
@@ -220,8 +212,8 @@ class CostModelTests(TestCase):
         self.assertEqual(self.invoice.workshops_summary, '')
         self.assertEqual(self.invoice.categories_summary, '')
 
-    def test_invoice_numbers_start_from_one_when_the_sequence_is_created(self):
-        other_invoice = Invoice.objects.create(
+    def test_invoice_numbers_follow_the_highest_stored_number(self):
+        Invoice.objects.create(
             user=self.user,
             camp=self.other_camp,
             document_number='FV/1/2027',
@@ -232,15 +224,9 @@ class CostModelTests(TestCase):
             description='Other edition',
             internal_number='WWW_2027_K_0041',
         )
-        InvoiceSequence.objects.create(
-            camp=self.other_camp,
-            invoice_type=Invoice.Type.KSEF,
-            last_allocated=41,
-        )
         empty_camp = Camp.objects.create(year=2028)
 
         first_number = allocate_invoice_number(camp=self.camp, invoice_type=Invoice.Type.KSEF)
-        second_number = allocate_invoice_number(camp=self.camp, invoice_type=Invoice.Type.KSEF)
         other_number = allocate_invoice_number(
             camp=self.other_camp,
             invoice_type=Invoice.Type.KSEF,
@@ -251,77 +237,38 @@ class CostModelTests(TestCase):
         )
 
         self.assertEqual(first_number, 'WWW_2026_K_0002')
-        self.assertEqual(second_number, 'WWW_2026_K_0003')
         self.assertEqual(other_number, 'WWW_2027_K_0042')
         self.assertEqual(empty_camp_number, 'WWW_2028_K_0001')
-        self.assertEqual(
-            InvoiceSequence.objects.get(
-                camp=self.camp,
-                invoice_type=Invoice.Type.KSEF,
-            ).last_allocated,
-            3,
-        )
-        self.assertEqual(
-            InvoiceSequence.objects.get(
-                camp=other_invoice.camp,
-                invoice_type=Invoice.Type.KSEF,
-            ).last_allocated,
-            42,
-        )
 
-    def test_invoice_types_use_separate_numbering_series(self):
+    def test_outside_ksef_and_nip_receipts_share_the_fvp_series(self):
         expected_numbers = {
             Invoice.Type.KSEF: 'WWW_2026_K_0002',
-            Invoice.Type.OUTSIDE_KSEF: 'WWW_2026_L_0001',
-            Invoice.Type.RECEIPT_WITH_NIP: 'WWW_2026_P_0001',
+            Invoice.Type.OUTSIDE_KSEF: 'WWW_2026_FVP_0001',
+            Invoice.Type.RECEIPT_WITH_NIP: 'WWW_2026_FVP_0002',
             Invoice.Type.NON_ACCOUNTING_RECEIPT: 'WWW_2026_NP_0001',
         }
 
-        allocated_numbers = {
-            invoice_type: allocate_invoice_number(
+        allocated_numbers = {}
+        for index, invoice_type in enumerate(expected_numbers):
+            allocated_number = allocate_invoice_number(
                 camp=self.camp,
                 invoice_type=invoice_type,
             )
-            for invoice_type in expected_numbers
-        }
+            allocated_numbers[invoice_type] = allocated_number
+            Invoice.objects.create(
+                user=self.user,
+                camp=self.camp,
+                attachment=f'invoices/allocated-{index}.pdf',
+                document_number=f'ALLOCATED/{index}/2026',
+                issue_date='2026-07-24',
+                amount=Decimal('1.00'),
+                invoice_type=invoice_type,
+                description='Allocated number test',
+                status=Invoice.Status.APPROVED,
+                internal_number=allocated_number,
+            )
 
         self.assertEqual(allocated_numbers, expected_numbers)
-        self.assertEqual(
-            set(InvoiceSequence.objects.filter(camp=self.camp).values_list(
-                'invoice_type',
-                'last_allocated',
-            )),
-            {
-                (Invoice.Type.KSEF, 2),
-                (Invoice.Type.OUTSIDE_KSEF, 1),
-                (Invoice.Type.RECEIPT_WITH_NIP, 1),
-                (Invoice.Type.NON_ACCOUNTING_RECEIPT, 1),
-            },
-        )
-
-    def test_allocate_invoice_number_recovers_from_a_concurrent_sequence_creation(self):
-        camp = Camp.objects.create(year=2028)
-        InvoiceSequence.objects.create(
-            camp=camp,
-            invoice_type=Invoice.Type.KSEF,
-            last_allocated=1,
-        )
-
-        with patch.object(
-            InvoiceSequence.objects,
-            'get_or_create',
-            side_effect=lambda **kwargs: InvoiceSequence.objects.create(**kwargs),
-        ):
-            allocated = allocate_invoice_number(camp=camp, invoice_type=Invoice.Type.KSEF)
-
-        self.assertEqual(allocated, 'WWW_2028_K_0002')
-        self.assertEqual(
-            InvoiceSequence.objects.get(
-                camp=camp,
-                invoice_type=Invoice.Type.KSEF,
-            ).last_allocated,
-            2,
-        )
 
     def test_batch_transition_rolls_back_when_one_invoice_is_ineligible(self):
         received = self.create_invoice(
@@ -353,8 +300,8 @@ class CostModelTests(TestCase):
         camp = Camp.objects.create(year=2028)
         expected_numbers = (
             (Invoice.Type.KSEF, 'WWW_2028_K_0001'),
-            (Invoice.Type.OUTSIDE_KSEF, 'WWW_2028_L_0001'),
-            (Invoice.Type.RECEIPT_WITH_NIP, 'WWW_2028_P_0001'),
+            (Invoice.Type.OUTSIDE_KSEF, 'WWW_2028_FVP_0001'),
+            (Invoice.Type.RECEIPT_WITH_NIP, 'WWW_2028_FVP_0002'),
             (Invoice.Type.NON_ACCOUNTING_RECEIPT, 'WWW_2028_NP_0001'),
         )
 
@@ -379,19 +326,6 @@ class CostModelTests(TestCase):
 
             invoice.refresh_from_db()
             self.assertEqual(invoice.internal_number, expected_number)
-
-        self.assertEqual(
-            set(InvoiceSequence.objects.filter(camp=camp).values_list(
-                'invoice_type',
-                'last_allocated',
-            )),
-            {
-                (Invoice.Type.KSEF, 1),
-                (Invoice.Type.OUTSIDE_KSEF, 1),
-                (Invoice.Type.RECEIPT_WITH_NIP, 1),
-                (Invoice.Type.NON_ACCOUNTING_RECEIPT, 1),
-            },
-        )
 
     def test_transition_allows_only_the_defined_state_graph(self):
         allowed = {

--- a/wwwapp/tests/test_costs_views.py
+++ b/wwwapp/tests/test_costs_views.py
@@ -25,7 +25,6 @@ from wwwapp.models import (
     Camp,
     CostItem,
     Invoice,
-    InvoiceSequence,
     Reimbursement,
     SettlementDetails,
     UploadStorage,
@@ -298,11 +297,6 @@ class OwnCostsViewsTests(TestCase):
             invoice_type=Invoice.Type.KSEF,
             description='Workshop materials',
             internal_number='WWW_2026_K_0001',
-        )
-        InvoiceSequence.objects.create(
-            camp=self.camp,
-            invoice_type=Invoice.Type.KSEF,
-            last_allocated=1,
         )
 
     def invoice_post_data(self, **overrides):
@@ -678,10 +672,6 @@ class OwnCostsViewsTests(TestCase):
         self.assertRedirects(response, reverse('costs_mine', args=[self.camp.pk]))
         invoice = Invoice.objects.get(document_number='FV/2/2026')
         self.assertIsNone(invoice.internal_number)
-        self.assertFalse(InvoiceSequence.objects.filter(
-            camp=self.camp,
-            invoice_type=Invoice.Type.NON_ACCOUNTING_RECEIPT,
-        ).exists())
 
     def test_rejected_invoice_edit_resets_it_to_received(self):
         SettlementDetails.objects.create(

--- a/wwwapp/tests/test_invoice_numbering_migration.py
+++ b/wwwapp/tests/test_invoice_numbering_migration.py
@@ -168,3 +168,94 @@ class InvoiceTypeNumberingMigrationTests(TransactionTestCase):
             )
         InvoiceSequence.objects.create(camp=camp, series='FP', last_allocated=5)
         InvoiceSequence.objects.create(camp=camp, series='FPZ', last_allocated=1)
+
+
+class InvoiceFvpNumberingMigrationTests(TransactionTestCase):
+    migrate_from = [('wwwapp', '0094_renumber_invoices_by_type')]
+    migrate_to = [(
+        'wwwapp',
+        '0095_renumber_invoices_to_fvp_and_remove_invoicesequence',
+    )]
+
+    def setUp(self):
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_from)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+        self._create_invoices(old_apps)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def tearDown(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(executor.loader.graph.leaf_nodes())
+        super().tearDown()
+
+    def test_existing_invoices_use_k_fvp_and_np_series(self):
+        Invoice = self.apps.get_model('wwwapp', 'Invoice')
+
+        numbers_by_document = dict(Invoice.objects.values_list(
+            'document_number',
+            'internal_number',
+        ))
+
+        self.assertEqual(numbers_by_document, {
+            'TEST/K/1': 'WWW_2026_K_0001',
+            'TEST/L/1': 'WWW_2026_FVP_0001',
+            'TEST/P/1': 'WWW_2026_FVP_0002',
+            'TEST/NP/1': 'WWW_2026_NP_0001',
+            'TEST/K/2': 'WWW_2026_K_0002',
+            'TEST/RECEIVED': None,
+        })
+
+    def test_invoice_sequence_model_is_removed(self):
+        with self.assertRaises(LookupError):
+            self.apps.get_model('wwwapp', 'InvoiceSequence')
+
+    def _create_invoices(self, apps):
+        User = apps.get_model('auth', 'User')
+        Camp = apps.get_model('wwwapp', 'Camp')
+        Invoice = apps.get_model('wwwapp', 'Invoice')
+        InvoiceSequence = apps.get_model('wwwapp', 'InvoiceSequence')
+        user = User.objects.create(username='fvp-migration-user')
+        camp, _ = Camp.objects.get_or_create(year=2026)
+        invoice_data = (
+            ('KSEF', 'APPROVED', 'TEST/K/1', 'WWW_2026_K_0001'),
+            ('OUTSIDE_KSEF', 'APPROVED', 'TEST/L/1', 'WWW_2026_L_0001'),
+            ('RECEIPT_WITH_NIP', 'PROCESSED', 'TEST/P/1', 'WWW_2026_P_0001'),
+            (
+                'NON_ACCOUNTING_RECEIPT',
+                'APPROVED',
+                'TEST/NP/1',
+                'WWW_2026_NP_0001',
+            ),
+            ('KSEF', 'PROCESSED', 'TEST/K/2', 'WWW_2026_K_0002'),
+            ('OUTSIDE_KSEF', 'RECEIVED', 'TEST/RECEIVED', None),
+        )
+        for sequence, data in enumerate(invoice_data, start=1):
+            invoice_type, status, document_number, internal_number = data
+            Invoice.objects.create(
+                user=user,
+                camp=camp,
+                attachment=f'invoices/fvp-{sequence}.pdf',
+                document_number=document_number,
+                issue_date='2026-07-24',
+                amount='10.00',
+                invoice_type=invoice_type,
+                status=status,
+                description='FVP migration test',
+                internal_number=internal_number,
+            )
+        for invoice_type, last_allocated in (
+            ('KSEF', 2),
+            ('OUTSIDE_KSEF', 1),
+            ('RECEIPT_WITH_NIP', 1),
+            ('NON_ACCOUNTING_RECEIPT', 1),
+        ):
+            InvoiceSequence.objects.create(
+                camp=camp,
+                invoice_type=invoice_type,
+                last_allocated=last_allocated,
+            )

--- a/wwwapp/tests/test_populate_with_test_data.py
+++ b/wwwapp/tests/test_populate_with_test_data.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from wwwapp.management.commands.populate_with_test_data import Command
-from wwwapp.models import Invoice, InvoiceSequence, UploadStorage, UserProfile, Workshop
+from wwwapp.models import Invoice, UploadStorage, UserProfile, Workshop
 
 
 @override_settings(DEBUG=True, PASSWORD_HASHERS=['django.contrib.auth.hashers.MD5PasswordHasher'])
@@ -40,11 +40,17 @@ class PopulateWithTestData(TestCase):
                         invoices.values('user_id').distinct().count(),
                         len(Invoice.Status.values),
                     )
-                    sequence = InvoiceSequence.objects.get(
-                        camp=invoices.first().camp,
-                        invoice_type=Invoice.Type.KSEF,
+                    camp_year = invoices.first().camp_id
+                    self.assertEqual(
+                        set(invoices.exclude(internal_number=None).values_list(
+                            'internal_number',
+                            flat=True,
+                        )),
+                        {
+                            f'WWW_{camp_year}_K_0001',
+                            f'WWW_{camp_year}_K_0002',
+                        },
                     )
-                    self.assertEqual(sequence.last_allocated, 2)
                     self.assertEqual(
                         invoices.filter(internal_number__isnull=False)
                         .values('status')


### PR DESCRIPTION
## What changed

- use the `FVP` invoice series for outside-KSeF invoices and receipts with NIP
- keep separate `K` and `NP` series
- allocate new numbers from the highest persisted invoice number for the camp and series
- renumber existing approved and processed invoices with migration 0095
- remove the `InvoiceSequence` model and table
- update test-data generation and invoice numbering tests

## Impact

Outside-KSeF invoices and receipts with NIP now share one sequence. New invoice numbers no longer depend on stored counter rows.

## Validation

- `uv run --no-project --python .venv/bin/python python manage.py test -v 2` — 312 tests passed
- `uv run --no-project --python .venv/bin/python python manage.py makemigrations --check --dry-run` — no changes detected
- `git diff --check origin/master...HEAD`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/713)
<!-- Reviewable:end -->
