### PR TITLE
Fix date sorting in participants view (listpeople.html)

### DIFF
--- a/templates/listpeople.html
+++ b/templates/listpeople.html
@@ -138,13 +138,13 @@
                 </td>
                 {% for question, answer in person.form_answers %}
                   <td title="Ostatnia modyfikacja: {% if answer %}{{ answer.last_changed }}{% else %}Nigdy{% endif %}"
-                      {% if answer.question.data_type == 'd' %}data-order="{{ answer.value_date | date:"U" }}"{% endif %}>
+                      {% if question.data_type == 'd' %}{% if answer %}data-order="{{ answer.value_date | date:"U" }}"{% endif %}{% endif %}>
                     {{ answer.value }}
                   </td>
                   {% if question.data_type == 'P' %}
                   <td title="Ostatnia modyfikacja: {% if answer %}{{ answer.last_changed }}{% else %}Nigdy{% endif %}"
-                      data-order="{{ answer.pesel_extract_date | date:"U" }}">
-                    {{ answer.pesel_extract_date | question_mark_on_none_value }}
+                      {% if answer %}data-order="{{ answer.pesel_extract_date | date:"U" }}"{% endif %}>
+                    {% if answer %}{{ answer.pesel_extract_date | question_mark_on_none_value }}{% endif %}
                   </td>
                   {% endif %}
                 {% endfor %}


### PR DESCRIPTION
Use question.data_type instead of answer.question.data_type when determining if a column is a date type. When answer is None (user hasn't answered that form question), answer.question.data_type silently evaluates falsy, so data-order was never emitted.

Also add None guards for PESEL birth date column which was missing them entirely.

Fixes #513

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/warsztatywww/aplikacjawww/719)
<!-- Reviewable:end -->
